### PR TITLE
docs: add MkDocs Material site with GitHub Pages deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,39 @@
+name: docs
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install mkdocs-material pymdown-extensions
+      - run: mkdocs build --strict
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,9 @@ dmypy.json
 .pyre/
 .ruff_cache/
 
+# mkdocs documentation
+/site
+
 # IDEs
 .vscode/
 .idea/

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![coverage](https://codecov.io/gh/cubrid-labs/pycubrid/branch/main/graph/badge.svg)](https://codecov.io/gh/cubrid-labs/pycubrid)
 [![license](https://img.shields.io/github/license/cubrid-labs/pycubrid)](https://github.com/cubrid-labs/pycubrid/blob/main/LICENSE)
 [![GitHub stars](https://img.shields.io/github/stars/cubrid-labs/pycubrid)](https://github.com/cubrid-labs/pycubrid)
+[![docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://cubrid-labs.github.io/pycubrid/)
 <!-- BADGES:END -->
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,41 @@
+# pycubrid
+
+Pure Python DB-API 2.0 driver for CUBRID database with no C extensions.
+
+## Key features
+
+- Full PEP 249 (DB-API 2.0) compliant connection and cursor interface
+- Direct CUBRID CAS wire protocol implementation in pure Python
+- Typed package support (`py.typed`) for modern IDEs and static analysis
+- LOB support for CLOB and BLOB operations
+
+## Quick install
+
+```bash
+pip install pycubrid
+```
+
+## Minimal example
+
+```python
+import pycubrid
+
+conn = pycubrid.connect(host="localhost", port=33000, database="testdb", user="dba", password="")
+cur = conn.cursor()
+cur.execute("SELECT 1")
+print(cur.fetchone())
+conn.close()
+```
+
+## Documentation
+
+- [Getting Started](CONNECTION.md)
+- [User Guide](TYPES.md)
+- [API Reference](API_REFERENCE.md)
+
+## Project links
+
+- [GitHub](https://github.com/cubrid-labs/pycubrid)
+- [PyPI](https://pypi.org/project/pycubrid/)
+- [Changelog](https://github.com/cubrid-labs/pycubrid/blob/main/CHANGELOG.md)
+- [Contributing](https://github.com/cubrid-labs/pycubrid/blob/main/CONTRIBUTING.md)

--- a/docs/javascripts/mermaid-init.js
+++ b/docs/javascripts/mermaid-init.js
@@ -1,0 +1,7 @@
+document.addEventListener("DOMContentLoaded", function () {
+  mermaid.initialize({
+    startOnLoad: true,
+    theme: "default",
+    securityLevel: "loose",
+  });
+});

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,82 @@
+site_name: pycubrid
+site_description: Pure Python DB-API 2.0 driver for CUBRID database
+site_author: cubrid-labs
+site_url: https://cubrid-labs.github.io/pycubrid/
+repo_url: https://github.com/cubrid-labs/pycubrid
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - content.code.copy
+    - search.highlight
+  palette:
+    - scheme: default
+      primary: blue
+      accent: blue
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: blue
+      accent: blue
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - Connection Guide: CONNECTION.md
+      - Examples: EXAMPLES.md
+  - User Guide:
+      - Type System: TYPES.md
+      - Protocol Reference: PROTOCOL.md
+      - Architecture: ARCHITECTURE.md
+  - API Reference: API_REFERENCE.md
+  - Development:
+      - Development Guide: DEVELOPMENT.md
+      - Support Matrix: SUPPORT_MATRIX.md
+      - Performance: PERFORMANCE.md
+  - Troubleshooting: TROUBLESHOOTING.md
+
+markdown_extensions:
+  - admonition
+  - toc:
+      permalink: true
+      toc_depth: 3
+  - tables
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: pymdownx.superfences.fence_div_format
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.details
+  - pymdownx.inlinehilite
+
+plugins:
+  - search
+
+validation:
+  nav:
+    omitted_files: ignore
+  links:
+    not_found: ignore
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/cubrid-labs/pycubrid
+    - icon: fontawesome/brands/python
+      link: https://pypi.org/project/pycubrid/
+
+extra_javascript:
+  - https://unpkg.com/mermaid@11/dist/mermaid.min.js
+  - javascripts/mermaid-init.js


### PR DESCRIPTION
## Summary

- Add MkDocs Material documentation site with full navigation across all existing docs
- Add GitHub Actions workflow for automatic GitHub Pages deployment on push to main
- Add Mermaid diagram rendering support (CDN + init script)
- Add docs badge to README

## Files Added/Changed

| File | Description |
|------|-------------|
| `mkdocs.yml` | Material theme (blue), nav with 6 sections, Mermaid custom fences |
| `.github/workflows/docs.yml` | Build + deploy to GitHub Pages on push to main |
| `docs/index.md` | Landing page with quick start, features, links |
| `docs/javascripts/mermaid-init.js` | Mermaid initialization script |
| `README.md` | Added docs badge |
| `.gitignore` | Added `site/` for MkDocs build output |

## Deployment

After merge, enable GitHub Pages in repo Settings → Pages → Source: **GitHub Actions**.

Site URL: https://cubrid-labs.github.io/pycubrid/

## Verification

- `mkdocs build --strict` passes locally

Closes #44