### PR TITLE
perf: post-1.0 performance optimization cycle

### DIFF
--- a/pycubrid/connection.py
+++ b/pycubrid/connection.py
@@ -76,7 +76,7 @@ class Connection:
 
         self._socket: socket.socket | None = None
         self._connected = False
-        self._cas_info: bytes = b"\x00\x00\x00\x00"
+        self._cas_info: bytes | bytearray = b"\x00\x00\x00\x00"
         self._session_id = 0
         self._autocommit = False
         self._cursors: set[Cursor] = set()
@@ -333,7 +333,7 @@ class Connection:
             self._connected = False
             raise OperationalError("socket communication failed") from exc
 
-    def _recv_exact(self, sock: socket.socket, size: int) -> bytes:
+    def _recv_exact(self, sock: socket.socket, size: int) -> bytearray:
         """Receive exactly ``size`` bytes from the socket."""
         buf = bytearray(size)
         view = memoryview(buf)
@@ -343,7 +343,7 @@ class Connection:
             if n == 0:
                 raise OperationalError("connection lost during receive")
             pos += n
-        return bytes(buf)
+        return buf
 
     def _ensure_connected(self) -> None:
         """Raise ``InterfaceError`` when called on a closed connection."""

--- a/pycubrid/cursor.py
+++ b/pycubrid/cursor.py
@@ -14,6 +14,7 @@ from .protocol import (
     CloseQueryPacket,
     ColumnMetaData,
     FetchPacket,
+    GetLastInsertIdPacket,
     PrepareAndExecutePacket,
 )
 
@@ -127,16 +128,10 @@ class Cursor:
 
         if packet.statement_type == CUBRIDStatementType.INSERT:
             try:
-                lid_packet = PrepareAndExecutePacket(
-                    sql="SELECT LAST_INSERT_ID()",
-                    auto_commit=self._connection.autocommit,
-                )
+                lid_packet = GetLastInsertIdPacket()
                 self._connection._send_and_receive(lid_packet)
-                if lid_packet.rows and lid_packet.rows[0][0] is not None:
-                    val = lid_packet.rows[0][0]
-                    self._lastrowid = int(val) if val else None
-                if lid_packet.query_handle:
-                    self._connection._send_and_receive(CloseQueryPacket(lid_packet.query_handle))
+                if lid_packet.last_insert_id:
+                    self._lastrowid = int(lid_packet.last_insert_id)
             except Exception:
                 self._lastrowid = None
 

--- a/pycubrid/packet.py
+++ b/pycubrid/packet.py
@@ -36,8 +36,9 @@ _HEADER_SIZE = DataSize.DATA_LENGTH + DataSize.CAS_INFO
 
 
 class PacketWriter:
-    def __init__(self) -> None:
-        self._buffer: bytearray = bytearray()
+    def __init__(self, *, reserve_header: bool = True) -> None:
+        self._header_size: int = _HEADER_SIZE if reserve_header else 0
+        self._buffer: bytearray = bytearray(self._header_size)
 
     def add_byte(self, value: int) -> None:
         """Write a length-prefixed byte value."""
@@ -167,12 +168,16 @@ class PacketWriter:
             self._write_filler(length - len(fixed), filler)
 
     def to_bytes(self) -> bytes:
-        """Return all bytes currently written."""
+        return bytes(self._buffer[self._header_size :])
+
+    def finalize(self, cas_info: bytes | bytearray) -> bytes:
+        payload_len = len(self._buffer) - _HEADER_SIZE
+        struct.pack_into(">i", self._buffer, 0, payload_len)
+        self._buffer[4:8] = cas_info
         return bytes(self._buffer)
 
     def __len__(self) -> int:
-        """Return current buffer size."""
-        return len(self._buffer)
+        return len(self._buffer) - self._header_size
 
 
 class PacketReader:

--- a/pycubrid/packet.py
+++ b/pycubrid/packet.py
@@ -32,6 +32,9 @@ def parse_protocol_header(data: bytes) -> tuple[int, bytes]:
     return data_length, cas_info
 
 
+_HEADER_SIZE = DataSize.DATA_LENGTH + DataSize.CAS_INFO
+
+
 class PacketWriter:
     def __init__(self) -> None:
         self._buffer: bytearray = bytearray()
@@ -214,6 +217,9 @@ class PacketReader:
         end = start + count
         self._offset = end
         return bytes(self._buffer[start:end])
+
+    def _skip_bytes(self, count: int) -> None:
+        self._offset += count
 
     def _parse_null_terminated_string(self, length: int) -> str:
         if length <= 0:

--- a/pycubrid/packet.py
+++ b/pycubrid/packet.py
@@ -228,10 +228,9 @@ class PacketReader:
         start = self._offset
         end = start + length
         self._offset = end
-        view = self._buffer[start:end]
-        if view[-1] == 0:
-            view = view[:-1]
-        return bytes(view).decode("utf-8")
+        if self._buffer[end - 1] == 0:
+            return bytes(self._buffer[start : end - 1]).decode("utf-8")
+        return bytes(self._buffer[start:end]).decode("utf-8")
 
     def _parse_date(self, size: int = 0) -> datetime.date:
         year, month, day = _STRUCT_3H.unpack_from(self._buffer, self._offset)

--- a/pycubrid/protocol.py
+++ b/pycubrid/protocol.py
@@ -22,7 +22,7 @@ from .constants import (
     DataSize,
 )
 from .exceptions import DatabaseError, IntegrityError, ProgrammingError
-from .packet import PacketReader, PacketWriter, build_protocol_header
+from .packet import PacketReader, PacketWriter
 
 
 # ---------------------------------------------------------------------------
@@ -298,7 +298,7 @@ class OpenDatabasePacket:
 
     def write(self) -> bytes:
         """Serialize the open database packet (628 bytes, no header)."""
-        writer = PacketWriter()
+        writer = PacketWriter(reserve_header=False)
         writer._write_fixed_length_string(self.database, 32)
         writer._write_fixed_length_string(self.user, 32)
         writer._write_fixed_length_string(self.password, 32)
@@ -368,9 +368,7 @@ class PrepareAndExecutePacket:
         writer._write_int(0)  # cache time sec
         writer._write_int(0)  # cache time usec
         writer.add_int(0)  # query timeout
-        payload = writer.to_bytes()
-        header = build_protocol_header(len(payload), cas_info)
-        return header + payload
+        return writer.finalize(cas_info)
 
     def parse(self, data: bytes | bytearray) -> None:
         """Parse the prepare-and-execute response.
@@ -438,9 +436,7 @@ class PreparePacket:
         writer._write_null_terminated_string(self.sql)
         writer.add_byte(CCIPrepareOption.NORMAL)
         writer.add_byte(1 if self.auto_commit else 0)
-        payload = writer.to_bytes()
-        header = build_protocol_header(len(payload), cas_info)
-        return header + payload
+        return writer.finalize(cas_info)
 
     def parse(self, data: bytes | bytearray) -> None:
         """Parse the prepare response."""
@@ -498,9 +494,7 @@ class ExecutePacket:
         writer.add_byte(1)  # forward only
         writer.add_cache_time()
         writer.add_int(0)  # query timeout
-        payload = writer.to_bytes()
-        header = build_protocol_header(len(payload), cas_info)
-        return header + payload
+        return writer.finalize(cas_info)
 
     def parse(self, data: bytes | bytearray, columns: list[ColumnMetaData] | None = None) -> None:
         """Parse the execute response."""
@@ -565,9 +559,7 @@ class FetchPacket:
         writer.add_int(self.fetch_size)
         writer.add_byte(0)  # case sensitive
         writer.add_int(0)  # resultset index
-        payload = writer.to_bytes()
-        header = build_protocol_header(len(payload), cas_info)
-        return header + payload
+        return writer.finalize(cas_info)
 
     def parse(
         self,
@@ -601,9 +593,7 @@ class CommitPacket:
         writer = PacketWriter()
         writer._write_byte(CASFunctionCode.END_TRAN)
         writer.add_byte(CCITransactionType.COMMIT)
-        payload = writer.to_bytes()
-        header = build_protocol_header(len(payload), cas_info)
-        return header + payload
+        return writer.finalize(cas_info)
 
     def parse(self, data: bytes | bytearray) -> None:
         """Parse the commit response."""
@@ -623,9 +613,7 @@ class RollbackPacket:
         writer = PacketWriter()
         writer._write_byte(CASFunctionCode.END_TRAN)
         writer.add_byte(CCITransactionType.ROLLBACK)
-        payload = writer.to_bytes()
-        header = build_protocol_header(len(payload), cas_info)
-        return header + payload
+        return writer.finalize(cas_info)
 
     def parse(self, data: bytes | bytearray) -> None:
         """Parse the rollback response."""
@@ -644,9 +632,7 @@ class CloseDatabasePacket:
         """Serialize the close database request."""
         writer = PacketWriter()
         writer._write_byte(CASFunctionCode.CON_CLOSE)
-        payload = writer.to_bytes()
-        header = build_protocol_header(len(payload), cas_info)
-        return header + payload
+        return writer.finalize(cas_info)
 
     def parse(self, data: bytes | bytearray) -> None:
         """Parse the close database response."""
@@ -669,9 +655,7 @@ class CloseQueryPacket:
         writer = PacketWriter()
         writer._write_byte(CASFunctionCode.CLOSE_REQ_HANDLE)
         writer.add_int(self.query_handle)
-        payload = writer.to_bytes()
-        header = build_protocol_header(len(payload), cas_info)
-        return header + payload
+        return writer.finalize(cas_info)
 
     def parse(self, data: bytes | bytearray) -> None:
         """Parse the close query response."""
@@ -695,9 +679,7 @@ class GetEngineVersionPacket:
         writer = PacketWriter()
         writer._write_byte(CASFunctionCode.GET_DB_VERSION)
         writer.add_byte(1 if self.auto_commit else 0)
-        payload = writer.to_bytes()
-        header = build_protocol_header(len(payload), cas_info)
-        return header + payload
+        return writer.finalize(cas_info)
 
     def parse(self, data: bytes | bytearray) -> None:
         """Parse the get engine version response."""
@@ -735,9 +717,7 @@ class GetSchemaPacket:
         writer.add_int(self.schema_type)
         writer._write_null_terminated_string(self.table_name)
         writer.add_byte(self.pattern_match_flag)
-        payload = writer.to_bytes()
-        header = build_protocol_header(len(payload), cas_info)
-        return header + payload
+        return writer.finalize(cas_info)
 
     def parse(self, data: bytes | bytearray) -> None:
         """Parse the get schema response."""
@@ -775,9 +755,7 @@ class BatchExecutePacket:
             writer.add_int(0)  # timeout
         for sql in self.sql_list:
             writer._write_null_terminated_string(sql)
-        payload = writer.to_bytes()
-        header = build_protocol_header(len(payload), cas_info)
-        return header + payload
+        return writer.finalize(cas_info)
 
     def parse(self, data: bytes | bytearray) -> None:
         """Parse the batch execute response."""
@@ -819,9 +797,7 @@ class LOBNewPacket:
         writer = PacketWriter()
         writer._write_byte(CASFunctionCode.LOB_NEW)
         writer.add_int(self.lob_type)
-        payload = writer.to_bytes()
-        header = build_protocol_header(len(payload), cas_info)
-        return header + payload
+        return writer.finalize(cas_info)
 
     def parse(self, data: bytes | bytearray) -> None:
         """Parse the LOB new response."""
@@ -850,9 +826,7 @@ class LOBWritePacket:
         writer.add_bytes(self.packed_lob_handle)
         writer.add_long(self.offset)
         writer.add_bytes(self.data)
-        payload = writer.to_bytes()
-        header = build_protocol_header(len(payload), cas_info)
-        return header + payload
+        return writer.finalize(cas_info)
 
     def parse(self, data: bytes | bytearray) -> None:
         """Parse the LOB write response."""
@@ -882,9 +856,7 @@ class LOBReadPacket:
         writer.add_bytes(self.packed_lob_handle)
         writer.add_long(self.offset)
         writer.add_int(self.length)
-        payload = writer.to_bytes()
-        header = build_protocol_header(len(payload), cas_info)
-        return header + payload
+        return writer.finalize(cas_info)
 
     def parse(self, data: bytes | bytearray) -> None:
         """Parse the LOB read response."""
@@ -909,9 +881,7 @@ class GetLastInsertIdPacket:
         """Serialize the get last insert ID request."""
         writer = PacketWriter()
         writer._write_byte(CASFunctionCode.GET_LAST_INSERT_ID)
-        payload = writer.to_bytes()
-        header = build_protocol_header(len(payload), cas_info)
-        return header + payload
+        return writer.finalize(cas_info)
 
     def parse(self, data: bytes | bytearray) -> None:
         """Parse the get last insert ID response."""
@@ -937,9 +907,7 @@ class GetDbParameterPacket:
         writer = PacketWriter()
         writer._write_byte(CASFunctionCode.GET_DB_PARAMETER)
         writer.add_int(self.parameter)
-        payload = writer.to_bytes()
-        header = build_protocol_header(len(payload), cas_info)
-        return header + payload
+        return writer.finalize(cas_info)
 
     def parse(self, data: bytes | bytearray) -> None:
         """Parse the get db parameter response."""
@@ -965,9 +933,7 @@ class SetDbParameterPacket:
         writer._write_byte(CASFunctionCode.SET_DB_PARAMETER)
         writer.add_int(self.parameter)
         writer.add_int(self.value)
-        payload = writer.to_bytes()
-        header = build_protocol_header(len(payload), cas_info)
-        return header + payload
+        return writer.finalize(cas_info)
 
     def parse(self, data: bytes | bytearray) -> None:
         """Parse the set db parameter response."""

--- a/pycubrid/protocol.py
+++ b/pycubrid/protocol.py
@@ -30,7 +30,7 @@ from .packet import PacketReader, PacketWriter, build_protocol_header
 # ---------------------------------------------------------------------------
 
 
-@dataclass
+@dataclass(slots=True)
 class ColumnMetaData:
     """Metadata for a single result column."""
 
@@ -51,7 +51,7 @@ class ColumnMetaData:
     is_shared: bool = False
 
 
-@dataclass
+@dataclass(slots=True)
 class ResultInfo:
     """Result info for each executed statement."""
 

--- a/pycubrid/protocol.py
+++ b/pycubrid/protocol.py
@@ -891,8 +891,10 @@ class GetLastInsertIdPacket:
         if response_code < 0:
             remaining = len(data) - 8
             _raise_error(reader, remaining)
-        if response_code > 0:
-            self.last_insert_id = reader._parse_null_terminated_string(response_code)
+        value_size = reader._parse_int()
+        if value_size > 2:
+            reader._skip_bytes(2)
+            self.last_insert_id = reader._parse_null_terminated_string(value_size - 2)
 
 
 class GetDbParameterPacket:

--- a/pycubrid/protocol.py
+++ b/pycubrid/protocol.py
@@ -279,7 +279,7 @@ class ClientInfoExchangePacket:
         buf.extend(b"\x00\x00\x00")
         return bytes(buf)
 
-    def parse(self, data: bytes) -> None:
+    def parse(self, data: bytes | bytearray) -> None:
         """Parse the handshake response (4-byte int)."""
         self.new_connection_port = struct.unpack(">i", data[:4])[0]
 
@@ -306,7 +306,7 @@ class OpenDatabasePacket:
         writer._write_filler(20)  # reserved
         return writer.to_bytes()
 
-    def parse(self, data: bytes) -> None:
+    def parse(self, data: bytes | bytearray) -> None:
         """Parse the open database response.
 
         ``data`` starts after the 4-byte DATA_LENGTH prefix, so it begins
@@ -372,7 +372,7 @@ class PrepareAndExecutePacket:
         header = build_protocol_header(len(payload), cas_info)
         return header + payload
 
-    def parse(self, data: bytes) -> None:
+    def parse(self, data: bytes | bytearray) -> None:
         """Parse the prepare-and-execute response.
 
         ``data`` starts after the 4-byte DATA_LENGTH prefix.
@@ -442,7 +442,7 @@ class PreparePacket:
         header = build_protocol_header(len(payload), cas_info)
         return header + payload
 
-    def parse(self, data: bytes) -> None:
+    def parse(self, data: bytes | bytearray) -> None:
         """Parse the prepare response."""
         reader = PacketReader(data)
         reader._skip_bytes(DataSize.CAS_INFO)
@@ -502,7 +502,7 @@ class ExecutePacket:
         header = build_protocol_header(len(payload), cas_info)
         return header + payload
 
-    def parse(self, data: bytes, columns: list[ColumnMetaData] | None = None) -> None:
+    def parse(self, data: bytes | bytearray, columns: list[ColumnMetaData] | None = None) -> None:
         """Parse the execute response."""
         if columns is not None:
             self.columns = columns
@@ -571,7 +571,7 @@ class FetchPacket:
 
     def parse(
         self,
-        data: bytes,
+        data: bytes | bytearray,
         columns: list[ColumnMetaData] | None = None,
         statement_type: int | None = None,
     ) -> None:
@@ -605,7 +605,7 @@ class CommitPacket:
         header = build_protocol_header(len(payload), cas_info)
         return header + payload
 
-    def parse(self, data: bytes) -> None:
+    def parse(self, data: bytes | bytearray) -> None:
         """Parse the commit response."""
         reader = PacketReader(data)
         reader._skip_bytes(DataSize.CAS_INFO)
@@ -627,7 +627,7 @@ class RollbackPacket:
         header = build_protocol_header(len(payload), cas_info)
         return header + payload
 
-    def parse(self, data: bytes) -> None:
+    def parse(self, data: bytes | bytearray) -> None:
         """Parse the rollback response."""
         reader = PacketReader(data)
         reader._skip_bytes(DataSize.CAS_INFO)
@@ -648,7 +648,7 @@ class CloseDatabasePacket:
         header = build_protocol_header(len(payload), cas_info)
         return header + payload
 
-    def parse(self, data: bytes) -> None:
+    def parse(self, data: bytes | bytearray) -> None:
         """Parse the close database response."""
         reader = PacketReader(data)
         reader._skip_bytes(DataSize.CAS_INFO)
@@ -673,7 +673,7 @@ class CloseQueryPacket:
         header = build_protocol_header(len(payload), cas_info)
         return header + payload
 
-    def parse(self, data: bytes) -> None:
+    def parse(self, data: bytes | bytearray) -> None:
         """Parse the close query response."""
         reader = PacketReader(data)
         reader._skip_bytes(DataSize.CAS_INFO)
@@ -699,7 +699,7 @@ class GetEngineVersionPacket:
         header = build_protocol_header(len(payload), cas_info)
         return header + payload
 
-    def parse(self, data: bytes) -> None:
+    def parse(self, data: bytes | bytearray) -> None:
         """Parse the get engine version response."""
         reader = PacketReader(data)
         reader._skip_bytes(DataSize.CAS_INFO)
@@ -739,7 +739,7 @@ class GetSchemaPacket:
         header = build_protocol_header(len(payload), cas_info)
         return header + payload
 
-    def parse(self, data: bytes) -> None:
+    def parse(self, data: bytes | bytearray) -> None:
         """Parse the get schema response."""
         reader = PacketReader(data)
         reader._skip_bytes(DataSize.CAS_INFO)
@@ -779,7 +779,7 @@ class BatchExecutePacket:
         header = build_protocol_header(len(payload), cas_info)
         return header + payload
 
-    def parse(self, data: bytes) -> None:
+    def parse(self, data: bytes | bytearray) -> None:
         """Parse the batch execute response."""
         reader = PacketReader(data)
         reader._skip_bytes(DataSize.CAS_INFO)
@@ -823,7 +823,7 @@ class LOBNewPacket:
         header = build_protocol_header(len(payload), cas_info)
         return header + payload
 
-    def parse(self, data: bytes) -> None:
+    def parse(self, data: bytes | bytearray) -> None:
         """Parse the LOB new response."""
         reader = PacketReader(data)
         reader._skip_bytes(DataSize.CAS_INFO)
@@ -854,7 +854,7 @@ class LOBWritePacket:
         header = build_protocol_header(len(payload), cas_info)
         return header + payload
 
-    def parse(self, data: bytes) -> None:
+    def parse(self, data: bytes | bytearray) -> None:
         """Parse the LOB write response."""
         reader = PacketReader(data)
         reader._skip_bytes(DataSize.CAS_INFO)
@@ -886,7 +886,7 @@ class LOBReadPacket:
         header = build_protocol_header(len(payload), cas_info)
         return header + payload
 
-    def parse(self, data: bytes) -> None:
+    def parse(self, data: bytes | bytearray) -> None:
         """Parse the LOB read response."""
         reader = PacketReader(data)
         reader._skip_bytes(DataSize.CAS_INFO)
@@ -913,7 +913,7 @@ class GetLastInsertIdPacket:
         header = build_protocol_header(len(payload), cas_info)
         return header + payload
 
-    def parse(self, data: bytes) -> None:
+    def parse(self, data: bytes | bytearray) -> None:
         """Parse the get last insert ID response."""
         reader = PacketReader(data)
         reader._skip_bytes(DataSize.CAS_INFO)
@@ -941,7 +941,7 @@ class GetDbParameterPacket:
         header = build_protocol_header(len(payload), cas_info)
         return header + payload
 
-    def parse(self, data: bytes) -> None:
+    def parse(self, data: bytes | bytearray) -> None:
         """Parse the get db parameter response."""
         reader = PacketReader(data)
         reader._skip_bytes(DataSize.CAS_INFO)
@@ -969,7 +969,7 @@ class SetDbParameterPacket:
         header = build_protocol_header(len(payload), cas_info)
         return header + payload
 
-    def parse(self, data: bytes) -> None:
+    def parse(self, data: bytes | bytearray) -> None:
         """Parse the set db parameter response."""
         reader = PacketReader(data)
         reader._skip_bytes(DataSize.CAS_INFO)

--- a/pycubrid/protocol.py
+++ b/pycubrid/protocol.py
@@ -884,7 +884,13 @@ class GetLastInsertIdPacket:
         return writer.finalize(cas_info)
 
     def parse(self, data: bytes | bytearray) -> None:
-        """Parse the get last insert ID response."""
+        """Parse the get last insert ID response.
+
+        The CAS protocol encodes dbval with a variable-length type header:
+        - If the first type byte has bit 7 set (``& 0x80``), the header is
+          2 bytes (e.g. ``0x83 0x07`` for CCI_U_TYPE_NUMERIC).
+        - Otherwise the header is 1 byte (legacy single-byte type).
+        """
         reader = PacketReader(data)
         reader._skip_bytes(DataSize.CAS_INFO)
         response_code = reader._parse_int()
@@ -892,9 +898,14 @@ class GetLastInsertIdPacket:
             remaining = len(data) - 8
             _raise_error(reader, remaining)
         value_size = reader._parse_int()
-        if value_size > 2:
-            reader._skip_bytes(2)
-            self.last_insert_id = reader._parse_null_terminated_string(value_size - 2)
+        if value_size > 0:
+            type_byte = reader._parse_byte()
+            type_header_size = 2 if (type_byte & 0x80) else 1
+            if type_header_size == 2:
+                reader._skip_bytes(1)  # consume second type byte
+            remaining = value_size - type_header_size
+            if remaining > 0:
+                self.last_insert_id = reader._parse_null_terminated_string(remaining)
 
 
 class GetDbParameterPacket:

--- a/pycubrid/protocol.py
+++ b/pycubrid/protocol.py
@@ -195,6 +195,7 @@ def _parse_row_data(
     _parse_int = reader._parse_int
     _parse_bytes = reader._parse_bytes
     _parse_byte = reader._parse_byte
+    _skip_bytes = reader._skip_bytes
     _null_type = CUBRIDDataType.NULL
     _oid_size = DataSize.OID
     _get = _TYPE_METHOD_NAMES.get
@@ -210,7 +211,7 @@ def _parse_row_data(
 
     for _ in range(tuple_count):
         _parse_int()
-        _parse_bytes(_oid_size)
+        _skip_bytes(_oid_size)
         row: list[Any] = [None] * ncols
         if col_readers is not None:
             for i in range(ncols):
@@ -377,7 +378,7 @@ class PrepareAndExecutePacket:
         ``data`` starts after the 4-byte DATA_LENGTH prefix.
         """
         reader = PacketReader(data)
-        _ = reader._parse_bytes(DataSize.CAS_INFO)  # cas_info
+        reader._skip_bytes(DataSize.CAS_INFO)
         self.response_code = reader._parse_int()
         if self.response_code < 0:
             remaining = len(data) - 8
@@ -444,7 +445,7 @@ class PreparePacket:
     def parse(self, data: bytes) -> None:
         """Parse the prepare response."""
         reader = PacketReader(data)
-        _ = reader._parse_bytes(DataSize.CAS_INFO)
+        reader._skip_bytes(DataSize.CAS_INFO)
         self.response_code = reader._parse_int()
         if self.response_code < 0:
             remaining = len(data) - 8
@@ -506,7 +507,7 @@ class ExecutePacket:
         if columns is not None:
             self.columns = columns
         reader = PacketReader(data)
-        _ = reader._parse_bytes(DataSize.CAS_INFO)
+        reader._skip_bytes(DataSize.CAS_INFO)
         response_code = reader._parse_int()
         if response_code < 0:
             remaining = len(data) - 8
@@ -576,7 +577,7 @@ class FetchPacket:
     ) -> None:
         """Parse the fetch response."""
         reader = PacketReader(data)
-        _ = reader._parse_bytes(DataSize.CAS_INFO)
+        reader._skip_bytes(DataSize.CAS_INFO)
         response_code = reader._parse_int()
         if response_code < 0:
             remaining = len(data) - 8
@@ -607,7 +608,7 @@ class CommitPacket:
     def parse(self, data: bytes) -> None:
         """Parse the commit response."""
         reader = PacketReader(data)
-        _ = reader._parse_bytes(DataSize.CAS_INFO)
+        reader._skip_bytes(DataSize.CAS_INFO)
         response_code = reader._parse_int()
         if response_code < 0:
             remaining = len(data) - 8
@@ -629,7 +630,7 @@ class RollbackPacket:
     def parse(self, data: bytes) -> None:
         """Parse the rollback response."""
         reader = PacketReader(data)
-        _ = reader._parse_bytes(DataSize.CAS_INFO)
+        reader._skip_bytes(DataSize.CAS_INFO)
         response_code = reader._parse_int()
         if response_code < 0:
             remaining = len(data) - 8
@@ -650,7 +651,7 @@ class CloseDatabasePacket:
     def parse(self, data: bytes) -> None:
         """Parse the close database response."""
         reader = PacketReader(data)
-        _ = reader._parse_bytes(DataSize.CAS_INFO)
+        reader._skip_bytes(DataSize.CAS_INFO)
         response_code = reader._parse_int()
         if response_code < 0:
             remaining = len(data) - 8
@@ -675,7 +676,7 @@ class CloseQueryPacket:
     def parse(self, data: bytes) -> None:
         """Parse the close query response."""
         reader = PacketReader(data)
-        _ = reader._parse_bytes(DataSize.CAS_INFO)
+        reader._skip_bytes(DataSize.CAS_INFO)
         response_code = reader._parse_int()
         if response_code < 0:
             remaining = len(data) - 8
@@ -701,7 +702,7 @@ class GetEngineVersionPacket:
     def parse(self, data: bytes) -> None:
         """Parse the get engine version response."""
         reader = PacketReader(data)
-        _ = reader._parse_bytes(DataSize.CAS_INFO)
+        reader._skip_bytes(DataSize.CAS_INFO)
         response_code = reader._parse_int()
         if response_code < 0:
             remaining = len(data) - 8
@@ -741,7 +742,7 @@ class GetSchemaPacket:
     def parse(self, data: bytes) -> None:
         """Parse the get schema response."""
         reader = PacketReader(data)
-        _ = reader._parse_bytes(DataSize.CAS_INFO)
+        reader._skip_bytes(DataSize.CAS_INFO)
         response_code = reader._parse_int()
         if response_code < 0:
             remaining = len(data) - 8
@@ -781,7 +782,7 @@ class BatchExecutePacket:
     def parse(self, data: bytes) -> None:
         """Parse the batch execute response."""
         reader = PacketReader(data)
-        _ = reader._parse_bytes(DataSize.CAS_INFO)
+        reader._skip_bytes(DataSize.CAS_INFO)
         response_code = reader._parse_int()
         if response_code < 0:
             remaining = len(data) - 8
@@ -825,7 +826,7 @@ class LOBNewPacket:
     def parse(self, data: bytes) -> None:
         """Parse the LOB new response."""
         reader = PacketReader(data)
-        _ = reader._parse_bytes(DataSize.CAS_INFO)
+        reader._skip_bytes(DataSize.CAS_INFO)
         response_code = reader._parse_int()
         if response_code < 0:
             remaining = len(data) - 8
@@ -856,7 +857,7 @@ class LOBWritePacket:
     def parse(self, data: bytes) -> None:
         """Parse the LOB write response."""
         reader = PacketReader(data)
-        _ = reader._parse_bytes(DataSize.CAS_INFO)
+        reader._skip_bytes(DataSize.CAS_INFO)
         response_code = reader._parse_int()
         if response_code < 0:
             remaining = len(data) - 8
@@ -888,7 +889,7 @@ class LOBReadPacket:
     def parse(self, data: bytes) -> None:
         """Parse the LOB read response."""
         reader = PacketReader(data)
-        _ = reader._parse_bytes(DataSize.CAS_INFO)
+        reader._skip_bytes(DataSize.CAS_INFO)
         response_code = reader._parse_int()
         if response_code < 0:
             remaining = len(data) - 8
@@ -915,7 +916,7 @@ class GetLastInsertIdPacket:
     def parse(self, data: bytes) -> None:
         """Parse the get last insert ID response."""
         reader = PacketReader(data)
-        _ = reader._parse_bytes(DataSize.CAS_INFO)
+        reader._skip_bytes(DataSize.CAS_INFO)
         response_code = reader._parse_int()
         if response_code < 0:
             remaining = len(data) - 8
@@ -943,7 +944,7 @@ class GetDbParameterPacket:
     def parse(self, data: bytes) -> None:
         """Parse the get db parameter response."""
         reader = PacketReader(data)
-        _ = reader._parse_bytes(DataSize.CAS_INFO)
+        reader._skip_bytes(DataSize.CAS_INFO)
         response_code = reader._parse_int()
         if response_code < 0:
             remaining = len(data) - 8
@@ -971,7 +972,7 @@ class SetDbParameterPacket:
     def parse(self, data: bytes) -> None:
         """Parse the set db parameter response."""
         reader = PacketReader(data)
-        _ = reader._parse_bytes(DataSize.CAS_INFO)
+        reader._skip_bytes(DataSize.CAS_INFO)
         response_code = reader._parse_int()
         if response_code < 0:
             remaining = len(data) - 8

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -18,7 +18,9 @@ def build_handshake_response(port: int = 0) -> bytes:
     return struct.pack(">i", port)
 
 
-def build_open_db_response(cas_info: bytes = b"\x01\x01\x02\x03", session_id: int = 1234) -> bytes:
+def build_open_db_response(
+    cas_info: bytes | bytearray = b"\x01\x01\x02\x03", session_id: int = 1234
+) -> bytes:
     body = cas_info + struct.pack(">i", 0)
     body += b"\x00" * 8
     body += struct.pack(">i", session_id)
@@ -26,19 +28,21 @@ def build_open_db_response(cas_info: bytes = b"\x01\x01\x02\x03", session_id: in
     return data_length + body
 
 
-def build_simple_ok_response(cas_info: bytes = b"\x01\x01\x02\x03") -> bytes:
+def build_simple_ok_response(cas_info: bytes | bytearray = b"\x01\x01\x02\x03") -> bytes:
     body = cas_info + struct.pack(">i", 0)
     return struct.pack(">i", len(body) - 4) + body
 
 
-def build_server_version_response(version: str, cas_info: bytes = b"\x01\x01\x02\x03") -> bytes:
+def build_server_version_response(
+    version: str, cas_info: bytes | bytearray = b"\x01\x01\x02\x03"
+) -> bytes:
     payload = version.encode("utf-8") + b"\x00"
     body = cas_info + struct.pack(">i", len(payload)) + payload
     return struct.pack(">i", len(body) - 4) + body
 
 
 def build_last_insert_id_response(
-    last_insert_id: str, cas_info: bytes = b"\x01\x01\x02\x03"
+    last_insert_id: str, cas_info: bytes | bytearray = b"\x01\x01\x02\x03"
 ) -> bytes:
     payload = last_insert_id.encode("utf-8") + b"\x00"
     body = cas_info + struct.pack(">i", len(payload)) + payload

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -44,8 +44,9 @@ def build_server_version_response(
 def build_last_insert_id_response(
     last_insert_id: str, cas_info: bytes | bytearray = b"\x01\x01\x02\x03"
 ) -> bytes:
-    payload = last_insert_id.encode("utf-8") + b"\x00"
-    body = cas_info + struct.pack(">i", len(payload)) + payload
+    value_bytes = last_insert_id.encode("utf-8") + b"\x00"
+    value_payload = b"\x83\x07" + value_bytes
+    body = cas_info + struct.pack(">i", 0) + struct.pack(">i", len(value_payload)) + value_payload
     return struct.pack(">i", len(body) - 4) + body
 
 

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -14,6 +14,7 @@ from pycubrid.protocol import (
     CloseQueryPacket,
     ColumnMetaData,
     FetchPacket,
+    GetLastInsertIdPacket,
     PrepareAndExecutePacket,
     ResultInfo,
 )
@@ -125,28 +126,16 @@ def test_execute_closes_existing_query_handle(cursor: Cursor, mock_connection: M
 def test_execute_insert_sets_rowcount_and_lastrowid(
     cursor: Cursor, mock_connection: MagicMock
 ) -> None:
-    call_count = 0
-
     def send(packet: object) -> object:
-        nonlocal call_count
         if isinstance(packet, PrepareAndExecutePacket):
-            call_count += 1
-            if call_count == 1:
-                # Main INSERT packet
-                _set_prepare_packet(
-                    packet,
-                    stmt_type=CUBRIDStatementType.INSERT,
-                    result_count=3,
-                    with_columns=False,
-                )
-            else:
-                # SELECT LAST_INSERT_ID() packet
-                packet.query_handle = 2
-                packet.statement_type = CUBRIDStatementType.SELECT
-                packet.columns = []
-                packet.total_tuple_count = 1
-                packet.rows = [(55,)]
-                packet.result_infos = []
+            _set_prepare_packet(
+                packet,
+                stmt_type=CUBRIDStatementType.INSERT,
+                result_count=3,
+                with_columns=False,
+            )
+        elif isinstance(packet, GetLastInsertIdPacket):
+            packet.last_insert_id = "55"
         return packet
 
     mock_connection._send_and_receive.side_effect = send
@@ -159,17 +148,11 @@ def test_execute_insert_sets_rowcount_and_lastrowid(
 def test_execute_insert_lastrowid_failure_is_ignored(
     cursor: Cursor, mock_connection: MagicMock
 ) -> None:
-    call_count = 0
-
     def send(packet: object) -> object:
-        nonlocal call_count
         if isinstance(packet, PrepareAndExecutePacket):
-            call_count += 1
-            if call_count == 1:
-                _set_prepare_packet(packet, stmt_type=CUBRIDStatementType.INSERT, result_count=1)
-            else:
-                # SELECT LAST_INSERT_ID() fails
-                raise RuntimeError("no id")
+            _set_prepare_packet(packet, stmt_type=CUBRIDStatementType.INSERT, result_count=1)
+        elif isinstance(packet, GetLastInsertIdPacket):
+            raise RuntimeError("no id")
         return packet
 
     mock_connection._send_and_receive.side_effect = send

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1347,15 +1347,19 @@ class TestGetLastInsertIdPacket:
 
     def test_parse_success(self) -> None:
         pkt = GetLastInsertIdPacket()
-        id_str = b"42\x00"
-        response = DEFAULT_CAS_INFO + struct.pack(">i", len(id_str)) + id_str
+        value_payload = b"\x83\x07" + b"42\x00"
+        response = (
+            DEFAULT_CAS_INFO
+            + struct.pack(">i", 0)
+            + struct.pack(">i", len(value_payload))
+            + value_payload
+        )
         pkt.parse(response)
         assert pkt.last_insert_id == "42"
 
     def test_parse_zero_response_code(self) -> None:
-        """responseCode=0 means no last insert id."""
         pkt = GetLastInsertIdPacket()
-        response = _build_success_response(DEFAULT_CAS_INFO, 0)
+        response = DEFAULT_CAS_INFO + struct.pack(">i", 0) + struct.pack(">i", -1)
         pkt.parse(response)
         assert pkt.last_insert_id == ""
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1345,7 +1345,7 @@ class TestGetLastInsertIdPacket:
         payload = data[8:]
         assert payload[0] == CASFunctionCode.GET_LAST_INSERT_ID
 
-    def test_parse_success(self) -> None:
+    def test_parse_2byte_type_header(self) -> None:
         pkt = GetLastInsertIdPacket()
         value_payload = b"\x83\x07" + b"42\x00"
         response = (
@@ -1357,11 +1357,35 @@ class TestGetLastInsertIdPacket:
         pkt.parse(response)
         assert pkt.last_insert_id == "42"
 
-    def test_parse_zero_response_code(self) -> None:
+    def test_parse_1byte_type_header(self) -> None:
+        pkt = GetLastInsertIdPacket()
+        value_payload = b"\x07" + b"42\x00"
+        response = (
+            DEFAULT_CAS_INFO
+            + struct.pack(">i", 0)
+            + struct.pack(">i", len(value_payload))
+            + value_payload
+        )
+        pkt.parse(response)
+        assert pkt.last_insert_id == "42"
+
+    def test_parse_null_value(self) -> None:
         pkt = GetLastInsertIdPacket()
         response = DEFAULT_CAS_INFO + struct.pack(">i", 0) + struct.pack(">i", -1)
         pkt.parse(response)
         assert pkt.last_insert_id == ""
+
+    def test_parse_bytearray_response(self) -> None:
+        pkt = GetLastInsertIdPacket()
+        value_payload = b"\x83\x07" + b"99\x00"
+        response = bytearray(
+            DEFAULT_CAS_INFO
+            + struct.pack(">i", 0)
+            + struct.pack(">i", len(value_payload))
+            + value_payload
+        )
+        pkt.parse(response)
+        assert pkt.last_insert_id == "99"
 
     def test_parse_error(self) -> None:
         pkt = GetLastInsertIdPacket()


### PR DESCRIPTION
## Summary

Post-1.0 performance optimization cycle targeting the CUBRID/MySQL driver-level gap.
Closes #53.

## Optimizations (7 commits)

1. **PacketReader._skip_bytes** — advance reader offset without allocating bytes for discarded data
2. **__slots__ on dataclasses** — ColumnMetaData and ResultInfo use `@dataclass(slots=True)`
3. **Null-terminated string parsing** — eliminate intermediate `view` variable allocation
4. **_skip_bytes for CAS_INFO + OID** — 17× CAS_INFO skips + per-row OID skip in fetch hot loop
5. **_recv_exact returns bytearray** — eliminate `bytes(buf)` copy on every server response
6. **PacketWriter.finalize()** — pre-allocate 8B header, write in-place; eliminates 3-copy → 1-copy on send path
7. **GetLastInsertIdPacket for INSERT lastrowid** — replace `PrepareAndExecute("SELECT LAST_INSERT_ID()") + CloseQuery` (3 round-trips) with single `GetLastInsertIdPacket` (1 round-trip)

## Benchmark Results

Same machine, same Docker containers (CUBRID 11.2 + MySQL 8.0), pycubrid 1.0.0 vs optimized:

| Operation | Before (1.0.0) | After | Change |
|-----------|:-:|:-:|:-:|
| **INSERT** | 398 ops/s | 640 ops/s | **+60.9%** |
| SELECT PK | 723 ops/s | 732 ops/s | +1.3% |
| **SELECT ALL** | 112 scan/s | 123 scan/s | **+10.1%** |
| UPDATE | 733 ops/s | 736 ops/s | +0.5% |
| DELETE | 751 ops/s | 746 ops/s | -0.6% |

**INSERT improved 61%** — primary driver was eliminating 2 extra round-trips per INSERT via `GetLastInsertIdPacket`.
**SELECT ALL (full scan) improved 10%** — from `_skip_bytes`, `__slots__`, and buffer optimizations in the fetch hot loop.

## Verification

- ✅ 531 offline tests passed, 99.08% coverage (≥95% gate)
- ✅ 41 integration tests passed (live CUBRID 11.2)
- ✅ mypy strict: 0 issues
- ✅ ruff: all checks passed
- ✅ No API breaking changes (1.x semver)

## Bug Fix (discovered during integration testing)

`GetLastInsertIdPacket.parse()` was incorrectly treating `response_code` as a string length.
The actual CAS wire format is: `response_code(4B) + size(4B) + type_byte(1B) + subtype_byte(1B) + value_string`.
Fixed to correctly decode the CAS-encoded DB_VALUE returned by `ux_get_last_insert_id()`.