### PR TITLE
feat: add asyncio support (pycubrid.aio)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Added
+- **Native asyncio support** via `pycubrid.aio` module
+  - `pycubrid.aio.connect()` — async connection factory
+  - `AsyncConnection` — async context manager, commit, rollback, cursor creation
+  - `AsyncCursor` — async execute, fetch (one/many/all), iterate, executemany
+  - Uses `loop.sock_*` non-blocking socket I/O — reuses existing protocol/packet layers
+- 30 new async offline tests (`tests/test_async.py`)
+
 ## [1.0.0] - 2026-04-11
 
 ### Stability Guarantee

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Korean public-sector and enterprise applications. The existing C-extension drive
 
 - **Pure Python implementation** — no C build dependencies, install with `pip install` only
 - **Full PEP 249 (DB-API 2.0) compliance** — standard exception hierarchy, type objects, cursor interface
-- **471 offline tests** with **99%+ code coverage** — no database required to run them
+- **501 offline tests** with **99%+ code coverage** — no database required to run them
+- **Native asyncio support** — async/await API via `pycubrid.aio` for high-concurrency applications
 - **PEP 561 typed package** — `py.typed` marker for modern IDE and static analysis support
 - **Direct CUBRID CAS protocol** implementation — no additional middleware required
 - **LOB (CLOB/BLOB) support** — handle large text and binary data
@@ -81,6 +82,25 @@ with pycubrid.connect(host="localhost", port=33000, database="testdb", user="dba
             print(row)
 ```
 
+### Async
+
+```python
+import asyncio
+import pycubrid.aio
+
+async def main():
+    conn = await pycubrid.aio.connect(
+        host="localhost", port=33000, database="testdb", user="dba"
+    )
+    cur = await conn.cursor()
+    await cur.execute("SELECT 1 + 1")
+    print(await cur.fetchone())  # (2,)
+    await cur.close()
+    await conn.close()
+
+asyncio.run(main())
+```
+
 ### Parameter Binding
 
 ```python
@@ -129,6 +149,7 @@ marketers = cur.fetchall()
 - **Server version detection** — `connection.get_server_version()` returns version string (e.g., `"11.2.0.0378"`)
 - **Iterator protocol** — iterate over cursor results with `for row in cursor`
 - **Context managers** — `with` statements for both connections and cursors
+- **Async support** — `pycubrid.aio.connect()` with `AsyncConnection` and `AsyncCursor` for asyncio event loops
 
 ## Supported CUBRID Versions
 
@@ -215,6 +236,8 @@ graph TD
     root --> packet
     root --> lob
     root --> typed
+    root --> aio
+    aio[aio/ - AsyncConnection, AsyncCursor, async connect()]
 ```
 
 ## FAQ
@@ -253,6 +276,10 @@ pycubrid has `threadsafety = 1`, meaning connections cannot be shared between th
 ### What CUBRID versions are supported?
 
 CUBRID 10.2, 11.0, 11.2, and 11.4 are tested in CI.
+
+### Does pycubrid support async/await?
+
+Yes. Use `pycubrid.aio.connect()` for native asyncio support. The async API mirrors the sync API — `AsyncConnection` and `AsyncCursor` provide the same methods with `await`.
 
 
 ## Related Projects

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,3 +28,10 @@
 ## Compatibility
 
 Python 3.10+, CUBRID 10.2–11.4
+
+## Completed
+
+### Async Support (v1.1.0)
+- Native asyncio API via `pycubrid.aio` module
+- `AsyncConnection` and `AsyncCursor` with full async/await support
+- Non-blocking socket I/O using `loop.sock_*`

--- a/pycubrid/aio/__init__.py
+++ b/pycubrid/aio/__init__.py
@@ -1,0 +1,50 @@
+"""pycubrid.aio — Async (asyncio) interface for the pycubrid CUBRID driver."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pycubrid.aio.connection import AsyncConnection
+
+
+async def connect(
+    host: str = "localhost",
+    port: int = 33000,
+    database: str = "",
+    user: str = "dba",
+    password: str = "",  # nosec B107 — PEP 249 default empty password
+    **kwargs: Any,
+) -> AsyncConnection:
+    """Create a new async database connection.
+
+    Args:
+        host: CUBRID server hostname or IP address.
+        port: CUBRID broker port (default 33000).
+        database: Database name.
+        user: Database user (default ``"dba"``).
+        password: Database password (default ``""``).
+        **kwargs: Additional connection parameters
+            (``autocommit``, ``connect_timeout``).
+
+    Returns:
+        A connected :class:`AsyncConnection` instance.
+    """
+    autocommit = kwargs.pop("autocommit", False)
+    conn = AsyncConnection(
+        host=host,
+        port=port,
+        database=database,
+        user=user,
+        password=password,
+        **kwargs,
+    )
+    await conn.connect()
+    if autocommit:
+        await conn.set_autocommit(True)
+    return conn
+
+
+__all__ = [
+    "connect",
+    "AsyncConnection",
+]

--- a/pycubrid/aio/connection.py
+++ b/pycubrid/aio/connection.py
@@ -1,0 +1,316 @@
+"""Async connection implementation for pycubrid."""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import struct
+import time
+from typing import TYPE_CHECKING, Any
+
+from pycubrid.constants import CCIDbParam, DataSize
+from pycubrid.exceptions import InterfaceError, OperationalError
+from pycubrid.protocol import (
+    ClientInfoExchangePacket,
+    CloseDatabasePacket,
+    CommitPacket,
+    GetEngineVersionPacket,
+    GetLastInsertIdPacket,
+    GetSchemaPacket,
+    OpenDatabasePacket,
+    RollbackPacket,
+    SetDbParameterPacket,
+)
+
+if TYPE_CHECKING:
+    from pycubrid.aio.cursor import AsyncCursor
+    from pycubrid.timing import TimingStats
+
+
+class AsyncConnection:
+    """Async connection to a CUBRID broker via the CAS protocol."""
+
+    _CAS_INFO_STATUS_INACTIVE: int = 0
+    _CAS_INFO_STATUS_ACTIVE: int = 1
+
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        database: str,
+        user: str,
+        password: str,
+        **kwargs: Any,
+    ) -> None:
+        self._host = host
+        self._port = port
+        self._database = database
+        self._user = user
+        self._password = password
+        self._connect_timeout = kwargs.get("connect_timeout")
+
+        self._timing: TimingStats | None = None
+        _enable_timing = kwargs.get("enable_timing")
+        if _enable_timing is None:
+            import os
+
+            _enable_timing = os.environ.get("PYCUBRID_ENABLE_TIMING", "").lower() in (
+                "1",
+                "true",
+                "yes",
+            )
+        if _enable_timing:
+            from pycubrid.timing import TimingStats as _TimingStats
+
+            self._timing = _TimingStats()
+
+        self._socket: socket.socket | None = None
+        self._connected = False
+        self._cas_info: bytes | bytearray = b"\x00\x00\x00\x00"
+        self._session_id = 0
+        self._autocommit = False
+        self._cursors: set[AsyncCursor] = set()
+        self._protocol_version: int = 1
+
+    async def connect(self) -> None:
+        """Establish a TCP CAS session with broker handshake and open database."""
+        if self._connected:
+            return
+
+        _timing = self._timing
+        _start = 0
+        if _timing is not None:
+            _start = time.perf_counter_ns()
+        try:
+            loop = asyncio.get_running_loop()
+
+            handshake_socket = self._create_socket_nonblocking(self._host, self._port)
+            await loop.sock_connect(handshake_socket, (self._host, self._port))
+
+            client_info_packet = ClientInfoExchangePacket()
+            await loop.sock_sendall(handshake_socket, client_info_packet.write())
+            handshake_response = await self._recv_exact_async(loop, handshake_socket, DataSize.INT)
+            client_info_packet.parse(handshake_response)
+
+            if client_info_packet.new_connection_port > 0:
+                handshake_socket.close()
+                self._socket = self._create_socket_nonblocking(
+                    self._host, client_info_packet.new_connection_port
+                )
+                await loop.sock_connect(
+                    self._socket,
+                    (self._host, client_info_packet.new_connection_port),
+                )
+            else:
+                self._socket = handshake_socket
+
+            open_db_packet = OpenDatabasePacket(
+                database=self._database,
+                user=self._user,
+                password=self._password,
+            )
+            await loop.sock_sendall(self._socket, open_db_packet.write())
+            data_length_bytes = await self._recv_exact_async(
+                loop, self._socket, DataSize.DATA_LENGTH
+            )
+            data_length = struct.unpack(">i", data_length_bytes)[0]
+            response_body = await self._recv_exact_async(
+                loop, self._socket, data_length + DataSize.CAS_INFO
+            )
+            open_db_packet.parse(response_body)
+
+            self._cas_info = open_db_packet.cas_info
+            self._session_id = open_db_packet.session_id
+            self._protocol_version = open_db_packet.broker_info.get("protocol_version", 1)
+            self._connected = True
+        except OSError as exc:
+            self._safe_close_socket()
+            raise OperationalError("failed to connect to CUBRID broker") from exc
+        finally:
+            if _timing is not None:
+                _timing.record_connect(time.perf_counter_ns() - _start)
+
+    async def close(self) -> None:
+        """Close the connection and all tracked cursors."""
+        if not self._connected:
+            return
+
+        _timing = self._timing
+        _start = 0
+        if _timing is not None:
+            _start = time.perf_counter_ns()
+
+        for cursor in list(self._cursors):
+            try:
+                await cursor.close()
+            except Exception:
+                pass
+            finally:
+                self._cursors.discard(cursor)
+
+        try:
+            await self._send_and_receive(CloseDatabasePacket())
+        except Exception:
+            pass
+        finally:
+            self._safe_close_socket()
+            self._connected = False
+            if _timing is not None:
+                _timing.record_close(time.perf_counter_ns() - _start)
+
+    async def commit(self) -> None:
+        """Commit the current transaction."""
+        self._ensure_connected()
+        await self._send_and_receive(CommitPacket())
+        self._invalidate_query_handles()
+
+    async def rollback(self) -> None:
+        """Roll back the current transaction."""
+        self._ensure_connected()
+        await self._send_and_receive(RollbackPacket())
+        self._invalidate_query_handles()
+
+    def cursor(self) -> AsyncCursor:
+        """Create and return a new async cursor bound to this connection."""
+        self._ensure_connected()
+        from pycubrid.aio.cursor import AsyncCursor
+
+        cur = AsyncCursor(self)
+        self._cursors.add(cur)
+        return cur
+
+    @property
+    def autocommit(self) -> bool:
+        self._ensure_connected()
+        return self._autocommit
+
+    async def set_autocommit(self, value: bool) -> None:
+        """Set auto-commit mode on the server."""
+        self._ensure_connected()
+        enabled = bool(value)
+        await self._send_and_receive(
+            SetDbParameterPacket(
+                parameter=CCIDbParam.AUTO_COMMIT,
+                value=1 if enabled else 0,
+            )
+        )
+        await self._send_and_receive(CommitPacket())
+        self._autocommit = enabled
+
+    @property
+    def timing_stats(self) -> TimingStats | None:
+        return self._timing
+
+    async def get_server_version(self) -> str:
+        self._ensure_connected()
+        packet = await self._send_and_receive(GetEngineVersionPacket(auto_commit=self._autocommit))
+        return packet.engine_version
+
+    async def get_last_insert_id(self) -> str:
+        self._ensure_connected()
+        packet = await self._send_and_receive(GetLastInsertIdPacket())
+        return packet.last_insert_id
+
+    async def get_schema_info(
+        self,
+        schema_type: int,
+        table_name: str = "",
+        pattern_match_flag: int = 1,
+    ) -> Any:
+        self._ensure_connected()
+        packet = GetSchemaPacket(
+            schema_type=schema_type,
+            table_name=table_name,
+            pattern_match_flag=pattern_match_flag,
+        )
+        await self._send_and_receive(packet)
+        return packet
+
+    async def __aenter__(self) -> AsyncConnection:
+        self._ensure_connected()
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        exc_type = args[0]
+        try:
+            if exc_type is None:
+                await self.commit()
+            else:
+                await self.rollback()
+        finally:
+            await self.close()
+
+    # -- internal I/O --------------------------------------------------------
+
+    def _create_socket_nonblocking(self, host: str, port: int) -> socket.socket:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+        sock.setblocking(False)
+        return sock
+
+    async def _send_and_receive(self, packet: Any) -> Any:
+        await self._check_reconnect()
+        if self._socket is None:
+            raise InterfaceError("connection is closed")
+
+        loop = asyncio.get_running_loop()
+        try:
+            request_data = packet.write(self._cas_info)
+            await loop.sock_sendall(self._socket, request_data)
+
+            data_length_bytes = await self._recv_exact_async(
+                loop, self._socket, DataSize.DATA_LENGTH
+            )
+            data_length = struct.unpack(">i", data_length_bytes)[0]
+            response_body = await self._recv_exact_async(
+                loop, self._socket, data_length + DataSize.CAS_INFO
+            )
+
+            self._cas_info = response_body[: DataSize.CAS_INFO]
+            packet.parse(response_body)
+            return packet
+        except OSError as exc:
+            self._safe_close_socket()
+            self._connected = False
+            raise OperationalError("socket communication failed") from exc
+
+    async def _recv_exact_async(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        sock: socket.socket,
+        size: int,
+    ) -> bytearray:
+        """Receive exactly *size* bytes from a non-blocking socket."""
+        buf = bytearray(size)
+        view = memoryview(buf)
+        pos = 0
+        while pos < size:
+            n = await loop.sock_recv_into(sock, view[pos:])
+            if n == 0:
+                raise OperationalError("connection lost during receive")
+            pos += n
+        return buf
+
+    async def _check_reconnect(self) -> None:
+        self._ensure_connected()
+        if self._cas_info[0] == self._CAS_INFO_STATUS_INACTIVE and self._socket is not None:
+            self._safe_close_socket()
+            self._connected = False
+            self._invalidate_query_handles()
+            await self.connect()
+
+    def _invalidate_query_handles(self) -> None:
+        for cursor in self._cursors:
+            cursor._query_handle = None
+
+    def _ensure_connected(self) -> None:
+        if not self._connected:
+            raise InterfaceError("connection is closed")
+
+    def _safe_close_socket(self) -> None:
+        if self._socket is not None:
+            try:
+                self._socket.close()
+            finally:
+                self._socket = None

--- a/pycubrid/aio/cursor.py
+++ b/pycubrid/aio/cursor.py
@@ -1,0 +1,369 @@
+"""Async cursor implementation for pycubrid."""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Any, Mapping, Sequence
+
+from pycubrid.constants import CUBRIDStatementType
+from pycubrid.exceptions import InterfaceError, ProgrammingError
+from pycubrid.protocol import (
+    BatchExecutePacket,
+    CloseQueryPacket,
+    ColumnMetaData,
+    FetchPacket,
+    GetLastInsertIdPacket,
+    PrepareAndExecutePacket,
+)
+
+if TYPE_CHECKING:
+    from pycubrid.aio.connection import AsyncConnection
+
+DescriptionItem = tuple[str, int, None, None, int, int, bool]
+
+
+class AsyncCursor:
+    """Async database cursor implementing a DB-API 2.0–like interface."""
+
+    def __init__(self, connection: AsyncConnection) -> None:
+        self._connection = connection
+        self._closed = False
+        self._description: tuple[DescriptionItem, ...] | None = None
+        self._rowcount: int = -1
+        self._arraysize: int = 1
+        self._query_handle: int | None = None
+        self._columns: list[ColumnMetaData] = []
+        self._rows: list[tuple[Any, ...]] = []
+        self._row_index: int = 0
+        self._statement_type: int = 0
+        self._total_tuple_count: int = 0
+        self._lastrowid: int | None = None
+        self._timing = connection._timing
+        self._connection._cursors.add(self)
+
+    @property
+    def description(self) -> tuple[DescriptionItem, ...] | None:
+        return self._description
+
+    @property
+    def rowcount(self) -> int:
+        return self._rowcount
+
+    @property
+    def lastrowid(self) -> int | None:
+        return self._lastrowid
+
+    @property
+    def arraysize(self) -> int:
+        return self._arraysize
+
+    @arraysize.setter
+    def arraysize(self, value: int) -> None:
+        if value < 1:
+            raise ProgrammingError("arraysize must be greater than zero")
+        self._arraysize = value
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+
+        if self._query_handle is not None:
+            self._connection._ensure_connected()
+            await self._connection._send_and_receive(CloseQueryPacket(self._query_handle))
+            self._query_handle = None
+
+        self._closed = True
+        self._connection._cursors.discard(self)
+
+    async def execute(
+        self,
+        operation: str,
+        parameters: Sequence[Any] | Mapping[str, Any] | None = None,
+    ) -> AsyncCursor:
+        self._check_closed()
+        self._connection._ensure_connected()
+
+        _timing = self._timing
+        _start = 0
+        if _timing is not None:
+            _start = time.perf_counter_ns()
+
+        if self._query_handle is not None:
+            await self._connection._send_and_receive(CloseQueryPacket(self._query_handle))
+            self._query_handle = None
+
+        sql = operation
+        if parameters is not None:
+            sql = self._bind_parameters(operation, parameters)
+
+        packet = PrepareAndExecutePacket(sql=sql, auto_commit=self._connection.autocommit)
+        await self._connection._send_and_receive(packet)
+
+        self._query_handle = packet.query_handle
+        self._statement_type = packet.statement_type
+        self._columns = list(packet.columns)
+        self._description = self._build_description(self._columns)
+        self._total_tuple_count = packet.total_tuple_count
+        self._rows = list(packet.rows)
+        self._row_index = 0
+        self._lastrowid = None
+
+        if packet.statement_type == CUBRIDStatementType.SELECT:
+            self._rowcount = -1
+        elif packet.result_infos:
+            self._rowcount = packet.result_infos[0].result_count
+        else:
+            self._rowcount = -1
+
+        if packet.statement_type == CUBRIDStatementType.INSERT:
+            try:
+                lid_packet = GetLastInsertIdPacket()
+                await self._connection._send_and_receive(lid_packet)
+                if lid_packet.last_insert_id:
+                    self._lastrowid = int(lid_packet.last_insert_id)
+            except Exception:
+                self._lastrowid = None
+
+        if _timing is not None:
+            _timing.record_execute(time.perf_counter_ns() - _start)
+
+        return self
+
+    async def executemany(
+        self,
+        operation: str,
+        seq_of_parameters: Sequence[Sequence[Any] | Mapping[str, Any]],
+    ) -> AsyncCursor:
+        self._check_closed()
+        if not seq_of_parameters:
+            return self
+
+        stripped = operation.lstrip()
+        is_select = stripped[:6].upper().startswith("SELECT")
+
+        if is_select:
+            for params in seq_of_parameters:
+                await self.execute(operation, params)
+            return self
+
+        sql_list = [self._bind_parameters(operation, params) for params in seq_of_parameters]
+        await self.executemany_batch(sql_list)
+        return self
+
+    async def executemany_batch(
+        self,
+        sql_list: list[str],
+        auto_commit: bool | None = None,
+    ) -> list[tuple[int, int]]:
+        self._check_closed()
+        self._connection._ensure_connected()
+
+        if auto_commit is None:
+            auto_commit = self._connection.autocommit
+
+        packet = BatchExecutePacket(
+            sql_list=sql_list,
+            auto_commit=auto_commit,
+            protocol_version=self._connection._protocol_version,
+        )
+        await self._connection._send_and_receive(packet)
+
+        self._description = None
+        self._rows = []
+        self._row_index = 0
+        self._query_handle = None
+
+        if packet.results:
+            self._rowcount = sum(count for _, count in packet.results)
+        else:
+            self._rowcount = 0
+
+        return packet.results
+
+    async def fetchone(self) -> tuple[Any, ...] | None:
+        self._check_closed()
+        self._check_result_set()
+
+        if self._row_index >= len(self._rows):
+            if not await self._fetch_more_rows():
+                return None
+
+        row = self._rows[self._row_index]
+        self._row_index += 1
+        return row
+
+    async def fetchmany(self, size: int | None = None) -> list[tuple[Any, ...]]:
+        self._check_closed()
+        self._check_result_set()
+        fetch_size = self.arraysize if size is None else size
+
+        rows: list[tuple[Any, ...]] = []
+        remaining = fetch_size
+        while remaining > 0:
+            available = len(self._rows) - self._row_index
+            if available <= 0:
+                if not await self._fetch_more_rows():
+                    break
+                available = len(self._rows) - self._row_index
+
+            take = min(available, remaining)
+            end = self._row_index + take
+            rows.extend(self._rows[self._row_index : end])
+            self._row_index = end
+            remaining -= take
+        return rows
+
+    async def fetchall(self) -> list[tuple[Any, ...]]:
+        self._check_closed()
+        self._check_result_set()
+
+        rows: list[tuple[Any, ...]] = []
+        while True:
+            available = len(self._rows) - self._row_index
+            if available > 0:
+                rows.extend(self._rows[self._row_index :])
+                self._row_index = len(self._rows)
+            if not await self._fetch_more_rows():
+                return rows
+
+    def setinputsizes(self, sizes: Any) -> None:
+        _ = sizes
+
+    def setoutputsize(self, size: int, column: int | None = None) -> None:
+        _ = (size, column)
+
+    async def callproc(self, procname: str, parameters: Sequence[Any] = ()) -> Sequence[Any]:
+        placeholders = ", ".join(["?"] * len(parameters))
+        if placeholders:
+            sql = "CALL %s(%s)" % (procname, placeholders)
+        else:
+            sql = "CALL %s()" % procname
+        await self.execute(sql, parameters)
+        return parameters
+
+    def __aiter__(self) -> AsyncCursor:
+        return self
+
+    async def __anext__(self) -> tuple[Any, ...]:
+        row = await self.fetchone()
+        if row is None:
+            raise StopAsyncIteration
+        return row
+
+    async def __aenter__(self) -> AsyncCursor:
+        self._check_closed()
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        _ = args
+        await self.close()
+
+    # -- internal helpers (no I/O) -------------------------------------------
+
+    def _check_closed(self) -> None:
+        if self._closed:
+            raise InterfaceError("Cursor is closed")
+
+    def _check_result_set(self) -> None:
+        if self._description is None:
+            raise InterfaceError("No result set available")
+
+    async def _fetch_more_rows(self) -> bool:
+        if self._query_handle is None:
+            return False
+        if self._row_index >= self._total_tuple_count:
+            return False
+
+        _timing = self._timing
+        _start = 0
+        if _timing is not None:
+            _start = time.perf_counter_ns()
+
+        packet = FetchPacket(
+            self._query_handle,
+            self._row_index,
+            fetch_size=100,
+            columns=self._columns,
+            statement_type=self._statement_type,
+        )
+        await self._connection._send_and_receive(packet)
+
+        if _timing is not None:
+            _timing.record_fetch(time.perf_counter_ns() - _start)
+
+        if not packet.rows:
+            return False
+
+        self._rows.extend(packet.rows)
+        return True
+
+    def _bind_parameters(
+        self,
+        operation: str,
+        parameters: Sequence[Any] | Mapping[str, Any],
+    ) -> str:
+        if isinstance(parameters, Mapping):
+            values = list(parameters.values())
+        elif isinstance(parameters, Sequence) and not isinstance(
+            parameters, (str, bytes, bytearray)
+        ):
+            values = list(parameters)
+        else:
+            raise ProgrammingError("parameters must be a sequence or mapping")
+
+        parts = operation.split("?")
+        placeholder_count = len(parts) - 1
+        if placeholder_count != len(values):
+            raise ProgrammingError("wrong number of parameters")
+
+        result = [parts[0]]
+        for index, value in enumerate(values, start=1):
+            result.append(self._format_parameter(value))
+            result.append(parts[index])
+        return "".join(result)
+
+    def _format_parameter(self, value: Any) -> str:
+        import datetime
+        from decimal import Decimal
+
+        if value is None:
+            return "NULL"
+        if isinstance(value, bool):
+            return "1" if value else "0"
+        if isinstance(value, str):
+            return "'%s'" % value.replace("'", "''")
+        if isinstance(value, bytes):
+            return "X'%s'" % value.hex()
+        if isinstance(value, datetime.datetime):
+            milliseconds = value.microsecond // 1000
+            return "DATETIME'%s.%03d'" % (
+                value.strftime("%Y-%m-%d %H:%M:%S"),
+                milliseconds,
+            )
+        if isinstance(value, datetime.date):
+            return "DATE'%s'" % value.strftime("%Y-%m-%d")
+        if isinstance(value, datetime.time):
+            return "TIME'%s'" % value.strftime("%H:%M:%S")
+        if isinstance(value, Decimal):
+            return str(value)
+        if isinstance(value, (int, float)):
+            return str(value)
+        raise ProgrammingError("unsupported parameter type")
+
+    def _build_description(
+        self, columns: list[ColumnMetaData]
+    ) -> tuple[DescriptionItem, ...] | None:
+        if not columns:
+            return None
+        return tuple(
+            (
+                column.name,
+                column.column_type,
+                None,
+                None,
+                column.precision,
+                column.scale,
+                column.is_nullable,
+            )
+            for column in columns
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = []
 [project.optional-dependencies]
 dev = [
     "pytest>=7.0",
+    "pytest-asyncio>=0.21",
     "pytest-cov",
     "ruff==0.15.8",
     "mypy==1.19.1",
@@ -47,7 +48,7 @@ Documentation = "https://github.com/cubrid-labs/pycubrid/tree/main/docs"
 Issues = "https://github.com/cubrid-labs/pycubrid/issues"
 
 [tool.setuptools]
-packages = ["pycubrid"]
+packages = ["pycubrid", "pycubrid.aio"]
 include-package-data = true
 
 [tool.ruff]

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,0 +1,424 @@
+from __future__ import annotations
+
+import asyncio
+import struct
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from pycubrid.aio.connection import AsyncConnection
+from pycubrid.aio.cursor import AsyncCursor
+from pycubrid.exceptions import InterfaceError, OperationalError
+
+
+def build_handshake_response(port: int = 0) -> bytes:
+    return struct.pack(">i", port)
+
+
+def build_open_db_response(
+    cas_info: bytes | bytearray = b"\x01\x01\x02\x03", session_id: int = 1234
+) -> bytes:
+    body = cas_info + struct.pack(">i", 0)
+    body += b"\x00" * 8
+    body += struct.pack(">i", session_id)
+    data_length = struct.pack(">i", len(body) - 4)
+    return data_length + body
+
+
+def build_simple_ok_response(cas_info: bytes | bytearray = b"\x01\x01\x02\x03") -> bytes:
+    body = cas_info + struct.pack(">i", 0)
+    return struct.pack(">i", len(body) - 4) + body
+
+
+class FakeLoop:
+    """Fake event loop that feeds pre-built byte sequences for socket operations."""
+
+    def __init__(self, recv_chunks: list[bytes]) -> None:
+        self._recv_chunks = list(recv_chunks)
+        self._recv_index = 0
+        self.sent_data: list[bytes] = []
+        self.connected_addresses: list[tuple[str, int]] = []
+
+    async def sock_connect(self, sock: MagicMock, address: tuple[str, int]) -> None:
+        self.connected_addresses.append(address)
+
+    async def sock_sendall(self, sock: MagicMock, data: bytes) -> None:
+        self.sent_data.append(data)
+
+    async def sock_recv_into(self, sock: MagicMock, buffer: memoryview) -> int:
+        if self._recv_index >= len(self._recv_chunks):
+            return 0
+        chunk = self._recv_chunks[self._recv_index]
+        self._recv_index += 1
+        n = len(chunk)
+        buffer[:n] = chunk
+        return n
+
+
+def make_fake_loop_for_connect(session_id: int = 1234) -> FakeLoop:
+    """Build a FakeLoop that provides handshake + open_db responses."""
+    open_db = build_open_db_response(session_id=session_id)
+    return FakeLoop(
+        [
+            build_handshake_response(),
+            open_db[:4],
+            open_db[4:],
+        ]
+    )
+
+
+@pytest.fixture
+def async_conn() -> AsyncConnection:
+    return AsyncConnection("localhost", 33000, "testdb", "dba", "")
+
+
+class TestAsyncConnectionEstablishment:
+    @pytest.mark.asyncio
+    async def test_connect_success(self, async_conn: AsyncConnection) -> None:
+        fake_loop = make_fake_loop_for_connect(session_id=777)
+
+        with (
+            patch("pycubrid.aio.connection.asyncio.get_running_loop", return_value=fake_loop),
+            patch.object(async_conn, "_create_socket_nonblocking", return_value=MagicMock()),
+        ):
+            await async_conn.connect()
+
+        assert async_conn._connected is True
+        assert async_conn._session_id == 777
+        assert async_conn._cas_info == b"\x01\x01\x02\x03"
+
+    @pytest.mark.asyncio
+    async def test_connect_with_port_redirection(self, async_conn: AsyncConnection) -> None:
+        open_db = build_open_db_response()
+        fake_loop = FakeLoop(
+            [
+                build_handshake_response(33100),
+                open_db[:4],
+                open_db[4:],
+            ]
+        )
+
+        sockets_created: list[MagicMock] = []
+
+        def track_socket(host: str, port: int) -> MagicMock:
+            s = MagicMock()
+            sockets_created.append(s)
+            return s
+
+        with (
+            patch("pycubrid.aio.connection.asyncio.get_running_loop", return_value=fake_loop),
+            patch.object(async_conn, "_create_socket_nonblocking", side_effect=track_socket),
+        ):
+            await async_conn.connect()
+
+        assert async_conn._connected is True
+        assert len(sockets_created) == 2
+        assert sockets_created[0].close.called
+        assert ("localhost", 33100) in fake_loop.connected_addresses
+
+    @pytest.mark.asyncio
+    async def test_connect_failure_raises_operational_error(
+        self, async_conn: AsyncConnection
+    ) -> None:
+        fake_loop = MagicMock()
+        fake_loop.sock_connect = AsyncMock(side_effect=OSError("boom"))
+
+        with (
+            patch("pycubrid.aio.connection.asyncio.get_running_loop", return_value=fake_loop),
+            patch.object(async_conn, "_create_socket_nonblocking", return_value=MagicMock()),
+        ):
+            with pytest.raises(OperationalError, match="failed to connect"):
+                await async_conn.connect()
+
+    @pytest.mark.asyncio
+    async def test_connect_noop_when_already_connected(self, async_conn: AsyncConnection) -> None:
+        async_conn._connected = True
+        await async_conn.connect()
+        assert async_conn._connected is True
+
+
+class TestAsyncConnectionClose:
+    @pytest.mark.asyncio
+    async def test_close_disconnects(self, async_conn: AsyncConnection) -> None:
+        fake_loop = make_fake_loop_for_connect()
+
+        with (
+            patch("pycubrid.aio.connection.asyncio.get_running_loop", return_value=fake_loop),
+            patch.object(async_conn, "_create_socket_nonblocking", return_value=MagicMock()),
+        ):
+            await async_conn.connect()
+
+        ok_resp = build_simple_ok_response()
+        close_loop = FakeLoop([ok_resp[:4], ok_resp[4:]])
+        with patch("pycubrid.aio.connection.asyncio.get_running_loop", return_value=close_loop):
+            await async_conn.close()
+
+        assert async_conn._connected is False
+        assert async_conn._socket is None
+
+    @pytest.mark.asyncio
+    async def test_close_noop_when_not_connected(self, async_conn: AsyncConnection) -> None:
+        await async_conn.close()
+        assert async_conn._connected is False
+
+
+class TestAsyncConnectionTransactions:
+    @pytest.mark.asyncio
+    async def test_commit(self, async_conn: AsyncConnection) -> None:
+        fake_loop = make_fake_loop_for_connect()
+        with (
+            patch("pycubrid.aio.connection.asyncio.get_running_loop", return_value=fake_loop),
+            patch.object(async_conn, "_create_socket_nonblocking", return_value=MagicMock()),
+        ):
+            await async_conn.connect()
+
+        ok_resp = build_simple_ok_response()
+        commit_loop = FakeLoop([ok_resp[:4], ok_resp[4:]])
+        with patch("pycubrid.aio.connection.asyncio.get_running_loop", return_value=commit_loop):
+            await async_conn.commit()
+
+    @pytest.mark.asyncio
+    async def test_rollback(self, async_conn: AsyncConnection) -> None:
+        fake_loop = make_fake_loop_for_connect()
+        with (
+            patch("pycubrid.aio.connection.asyncio.get_running_loop", return_value=fake_loop),
+            patch.object(async_conn, "_create_socket_nonblocking", return_value=MagicMock()),
+        ):
+            await async_conn.connect()
+
+        ok_resp = build_simple_ok_response()
+        rb_loop = FakeLoop([ok_resp[:4], ok_resp[4:]])
+        with patch("pycubrid.aio.connection.asyncio.get_running_loop", return_value=rb_loop):
+            await async_conn.rollback()
+
+    @pytest.mark.asyncio
+    async def test_commit_on_closed_raises(self, async_conn: AsyncConnection) -> None:
+        with pytest.raises(InterfaceError, match="connection is closed"):
+            await async_conn.commit()
+
+
+class TestAsyncConnectionContextManager:
+    @pytest.mark.asyncio
+    async def test_aenter_returns_self(self, async_conn: AsyncConnection) -> None:
+        async_conn._connected = True
+        result = await async_conn.__aenter__()
+        assert result is async_conn
+
+    @pytest.mark.asyncio
+    async def test_aexit_commits_on_success(self, async_conn: AsyncConnection) -> None:
+        fake_loop = make_fake_loop_for_connect()
+        with (
+            patch("pycubrid.aio.connection.asyncio.get_running_loop", return_value=fake_loop),
+            patch.object(async_conn, "_create_socket_nonblocking", return_value=MagicMock()),
+        ):
+            await async_conn.connect()
+
+        ok1 = build_simple_ok_response()
+        ok2 = build_simple_ok_response()
+        exit_loop = FakeLoop([ok1[:4], ok1[4:], ok2[:4], ok2[4:]])
+        with patch("pycubrid.aio.connection.asyncio.get_running_loop", return_value=exit_loop):
+            await async_conn.__aexit__(None, None, None)
+
+        assert async_conn._connected is False
+
+
+class TestAsyncConnectionCursor:
+    @pytest.mark.asyncio
+    async def test_cursor_returns_async_cursor(self, async_conn: AsyncConnection) -> None:
+        async_conn._connected = True
+        cur = async_conn.cursor()
+        assert isinstance(cur, AsyncCursor)
+        assert cur in async_conn._cursors
+
+    @pytest.mark.asyncio
+    async def test_cursor_on_closed_raises(self, async_conn: AsyncConnection) -> None:
+        with pytest.raises(InterfaceError, match="connection is closed"):
+            async_conn.cursor()
+
+
+class TestAsyncCursorProperties:
+    def test_description_default(self) -> None:
+        conn = MagicMock()
+        conn._timing = None
+        conn._cursors = set()
+        cur = AsyncCursor(conn)
+        assert cur.description is None
+
+    def test_rowcount_default(self) -> None:
+        conn = MagicMock()
+        conn._timing = None
+        conn._cursors = set()
+        cur = AsyncCursor(conn)
+        assert cur.rowcount == -1
+
+    def test_arraysize_default_and_setter(self) -> None:
+        conn = MagicMock()
+        conn._timing = None
+        conn._cursors = set()
+        cur = AsyncCursor(conn)
+        assert cur.arraysize == 1
+        cur.arraysize = 50
+        assert cur.arraysize == 50
+
+    def test_arraysize_rejects_zero(self) -> None:
+        conn = MagicMock()
+        conn._timing = None
+        conn._cursors = set()
+        cur = AsyncCursor(conn)
+        with pytest.raises(Exception, match="greater than zero"):
+            cur.arraysize = 0
+
+
+class TestAsyncCursorClose:
+    @pytest.mark.asyncio
+    async def test_close_sets_closed(self) -> None:
+        conn = MagicMock()
+        conn._timing = None
+        conn._cursors = set()
+        conn._ensure_connected = MagicMock()
+        conn._send_and_receive = AsyncMock()
+        cur = AsyncCursor(conn)
+        await cur.close()
+        assert cur._closed is True
+
+    @pytest.mark.asyncio
+    async def test_close_noop_when_already_closed(self) -> None:
+        conn = MagicMock()
+        conn._timing = None
+        conn._cursors = set()
+        cur = AsyncCursor(conn)
+        cur._closed = True
+        await cur.close()
+
+
+class TestAsyncCursorContextManager:
+    @pytest.mark.asyncio
+    async def test_aenter_returns_self(self) -> None:
+        conn = MagicMock()
+        conn._timing = None
+        conn._cursors = set()
+        cur = AsyncCursor(conn)
+        result = await cur.__aenter__()
+        assert result is cur
+
+    @pytest.mark.asyncio
+    async def test_aexit_closes(self) -> None:
+        conn = MagicMock()
+        conn._timing = None
+        conn._cursors = set()
+        conn._ensure_connected = MagicMock()
+        conn._send_and_receive = AsyncMock()
+        cur = AsyncCursor(conn)
+        await cur.__aexit__(None, None, None)
+        assert cur._closed is True
+
+
+class TestAsyncCursorIteration:
+    @pytest.mark.asyncio
+    async def test_aiter_returns_self(self) -> None:
+        conn = MagicMock()
+        conn._timing = None
+        conn._cursors = set()
+        cur = AsyncCursor(conn)
+        assert cur.__aiter__() is cur
+
+    @pytest.mark.asyncio
+    async def test_anext_raises_stop_when_no_rows(self) -> None:
+        conn = MagicMock()
+        conn._timing = None
+        conn._cursors = set()
+        cur = AsyncCursor(conn)
+        cur._description = (("id", 1, None, None, 0, 0, False),)
+        cur._rows = []
+        cur._row_index = 0
+        cur._query_handle = None
+        with pytest.raises(StopAsyncIteration):
+            await cur.__anext__()
+
+
+class TestAsyncCursorFetch:
+    @pytest.mark.asyncio
+    async def test_fetchone_returns_row(self) -> None:
+        conn = MagicMock()
+        conn._timing = None
+        conn._cursors = set()
+        cur = AsyncCursor(conn)
+        cur._description = (("id", 1, None, None, 0, 0, False),)
+        cur._rows = [(1,), (2,), (3,)]
+        cur._row_index = 0
+        cur._query_handle = None
+        cur._total_tuple_count = 3
+
+        row = await cur.fetchone()
+        assert row == (1,)
+        row = await cur.fetchone()
+        assert row == (2,)
+
+    @pytest.mark.asyncio
+    async def test_fetchall_returns_all_rows(self) -> None:
+        conn = MagicMock()
+        conn._timing = None
+        conn._cursors = set()
+        cur = AsyncCursor(conn)
+        cur._description = (("id", 1, None, None, 0, 0, False),)
+        cur._rows = [(1,), (2,), (3,)]
+        cur._row_index = 0
+        cur._query_handle = None
+        cur._total_tuple_count = 3
+
+        rows = await cur.fetchall()
+        assert rows == [(1,), (2,), (3,)]
+
+    @pytest.mark.asyncio
+    async def test_fetchmany_returns_requested_count(self) -> None:
+        conn = MagicMock()
+        conn._timing = None
+        conn._cursors = set()
+        cur = AsyncCursor(conn)
+        cur._description = (("id", 1, None, None, 0, 0, False),)
+        cur._rows = [(1,), (2,), (3,), (4,), (5,)]
+        cur._row_index = 0
+        cur._query_handle = None
+        cur._total_tuple_count = 5
+
+        rows = await cur.fetchmany(2)
+        assert rows == [(1,), (2,)]
+        rows = await cur.fetchmany(2)
+        assert rows == [(3,), (4,)]
+
+    @pytest.mark.asyncio
+    async def test_fetchone_on_closed_raises(self) -> None:
+        conn = MagicMock()
+        conn._timing = None
+        conn._cursors = set()
+        cur = AsyncCursor(conn)
+        cur._closed = True
+        with pytest.raises(InterfaceError, match="Cursor is closed"):
+            await cur.fetchone()
+
+    @pytest.mark.asyncio
+    async def test_fetchone_without_result_set_raises(self) -> None:
+        conn = MagicMock()
+        conn._timing = None
+        conn._cursors = set()
+        cur = AsyncCursor(conn)
+        with pytest.raises(InterfaceError, match="No result set"):
+            await cur.fetchone()
+
+
+class TestAsyncCursorBindParameters:
+    def test_bind_parameters(self) -> None:
+        conn = MagicMock()
+        conn._timing = None
+        conn._cursors = set()
+        cur = AsyncCursor(conn)
+        result = cur._bind_parameters("SELECT * FROM t WHERE id = ?", [42])
+        assert result == "SELECT * FROM t WHERE id = 42"
+
+    def test_bind_wrong_count_raises(self) -> None:
+        conn = MagicMock()
+        conn._timing = None
+        conn._cursors = set()
+        cur = AsyncCursor(conn)
+        with pytest.raises(Exception, match="wrong number"):
+            cur._bind_parameters("SELECT ?", [1, 2])


### PR DESCRIPTION
## Summary

Add native asyncio support via `pycubrid.aio` subpackage. Converts blocking socket I/O to non-blocking using `asyncio` event loop (`loop.sock_connect`, `loop.sock_sendall`, `loop.sock_recv_into`).

Closes #64

## What's included

### New files
- `pycubrid/aio/__init__.py` — public API: `await pycubrid.aio.connect(...)`
- `pycubrid/aio/connection.py` — `AsyncConnection` with async socket I/O
- `pycubrid/aio/cursor.py` — `AsyncCursor` with async execute/fetch/iterate
- `tests/test_async.py` — 30 offline tests

### Usage

```python
import pycubrid.aio

async def main():
    async with await pycubrid.aio.connect(
        host="localhost", port=33000, database="testdb", user="dba"
    ) as conn:
        cur = conn.cursor()
        await cur.execute("SELECT * FROM t WHERE id = ?", (1,))
        rows = await cur.fetchall()

        # async iteration
        await cur.execute("SELECT * FROM t")
        async for row in cur:
            print(row)
```

### Design decisions
- Uses `loop.sock_*` (non-blocking raw sockets) rather than `StreamReader`/`StreamWriter` — simpler, maps 1:1 to sync socket calls
- Reuses existing `protocol.py` / `packet.py` (pure serialization, no I/O) — zero duplication
- No new dependencies (stdlib `asyncio` only)
- Existing sync API completely unchanged

### Test results
```
tests/test_async.py       30 passed
tests/ (full suite)      563 passed, 49 skipped
```

## Blocks
- cubrid-labs/sqlalchemy-cubrid#109 — async dialect support (`create_async_engine`)