### PR TITLE
docs: add 4-phase development workflow rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,17 @@ pytest tests/test_integration.py -v
 - No Python 2 constructs
 - No empty `except` blocks
 
+## Development Workflow (cubrid-labs org standard)
+
+All non-trivial work across cubrid-labs repositories MUST follow this 4-phase cycle:
+
+1. **Oracle Design Review** — Consult Oracle before implementation to validate architecture, API surface, and approach. Raise concerns early.
+2. **Implementation** — Build the feature/fix with tests. Follow existing codebase patterns.
+3. **Documentation Update** — Update ALL affected docs (README, CHANGELOG, ROADMAP, API docs, SUPPORT_MATRIX, PRD, etc.) in the same PR or as an immediate follow-up. Code without doc updates is incomplete.
+4. **Oracle Post-Implementation Review** — Consult Oracle to review the completed work for correctness, edge cases, and consistency before merging.
+
+Skipping any phase requires explicit justification. Trivial changes (typos, single-line fixes) may skip phases 1 and 4.
+
 ## Test Structure
 
 ```mermaid


### PR DESCRIPTION
## Summary
- Add cubrid-labs org-standard 4-phase development workflow to AGENTS.md
- Phases: Oracle Design Review → Implementation → Documentation Update → Oracle Post-Implementation Review
- Applied consistently across all cubrid-labs repositories