### PR TITLE
chore: add release process, Makefile release target, and CI version check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  version-check:
+    name: Version consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Check pyproject.toml matches __init__.py
+        run: |
+          PYPROJECT_VER=$(grep -oP '^version = "\K[^"]+' pyproject.toml)
+          INIT_VER=$(python3 -c "import pycubrid; print(pycubrid.__version__)")
+          echo "pyproject.toml: $PYPROJECT_VER"
+          echo "__init__.py:    $INIT_VER"
+          if [ "$PYPROJECT_VER" != "$INIT_VER" ]; then
+            echo "::error::Version mismatch: pyproject.toml=$PYPROJECT_VER, __init__.py=$INIT_VER"
+            exit 1
+          fi
+          echo "Versions match: $PYPROJECT_VER"
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,23 @@ All non-trivial work across cubrid-labs repositories MUST follow this 4-phase cy
 
 Skipping any phase requires explicit justification. Trivial changes (typos, single-line fixes) may skip phases 1 and 4.
 
+## Release Process
+
+Version is tracked in TWO files — both MUST be updated together:
+- `pyproject.toml` → `version = "x.y.z"`
+- `pycubrid/__init__.py` → `__version__ = "x.y.z"`
+
+Steps:
+1. `make release VERSION=x.y.z` (bumps both files, validates consistency)
+2. Add changelog entry in `CHANGELOG.md`
+3. Commit: `release: vx.y.z — <summary>`
+4. Tag: `git tag vx.y.z`
+5. Push with tags: `git push origin main --tags`
+6. Create GitHub release: `gh release create vx.y.z --title "..."`
+7. PyPI publish triggers automatically from tag push (`.github/workflows/publish-pypi.yml`)
+
+**CI enforces version consistency** — `pyproject.toml` version must match `__init__.py` `__version__` on every PR.
+
 ## Test Structure
 
 ```mermaid

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install lint format typecheck security check check-all test integration docker-up docker-down changelog clean clean-all doctor
+.PHONY: help install lint format typecheck security check check-all test integration docker-up docker-down changelog clean clean-all doctor release
 
 PYTEST = python3 -m pytest
 RUFF = ruff
@@ -73,3 +73,16 @@ doctor: ## Check development environment
 	@$(BANDIT) --version || echo "ERROR: bandit not found"
 	@pre-commit --version || echo "ERROR: pre-commit not found"
 	@echo "All checks passed!"
+
+release: ## Bump version in pyproject.toml and __init__.py
+	@if [ -z "$(VERSION)" ]; then echo "Usage: make release VERSION=x.y.z"; exit 1; fi
+	@echo "Bumping version to $(VERSION)..."
+	@sed -i 's/^version = ".*"/version = "$(VERSION)"/' pyproject.toml
+	@sed -i 's/^__version__ = ".*"/__version__ = "$(VERSION)"/' pycubrid/__init__.py
+	@echo "Verifying consistency..."
+	@PYPROJECT_VER=$$(grep -oP '^version = "\K[^"]+' pyproject.toml); \
+	 INIT_VER=$$(python3 -c "import ast; print(next(node.value.value for node in ast.walk(ast.parse(open('pycubrid/__init__.py').read())) if isinstance(node, ast.Assign) and any(t.id == '__version__' for t in node.targets if isinstance(node, ast.Name))))"); \
+	 if [ "$$PYPROJECT_VER" != "$$INIT_VER" ]; then \
+	   echo "ERROR: Version mismatch — pyproject.toml=$$PYPROJECT_VER, __init__.py=$$INIT_VER"; exit 1; \
+	 fi
+	@echo "Version $(VERSION) set in pyproject.toml and pycubrid/__init__.py"


### PR DESCRIPTION
Closes #67

## Summary
- Add Release Process section to AGENTS.md documenting version bump procedure
- Add `make release VERSION=x.y.z` target that bumps both pyproject.toml and __init__.py atomically
- Add CI version consistency check job to catch mismatches on PRs