### PR TITLE
fix(bind): safe ? placeholder splitting with state-machine tokenizer

### DIFF
--- a/pycubrid/aio/cursor.py
+++ b/pycubrid/aio/cursor.py
@@ -16,7 +16,7 @@ from pycubrid.protocol import (
     GetLastInsertIdPacket,
     PrepareAndExecutePacket,
 )
-from pycubrid.cursor import _DML_BATCH_VERBS, _extract_first_keyword
+from pycubrid.cursor import _DML_BATCH_VERBS, _extract_first_keyword, _split_on_placeholders
 
 DescriptionItem = tuple[str, int, None, None, int, int, bool]
 
@@ -350,7 +350,7 @@ class AsyncCursor:
         else:
             raise ProgrammingError("parameters must be a sequence")
 
-        parts = operation.split("?")
+        parts = _split_on_placeholders(operation)
         placeholder_count = len(parts) - 1
         if placeholder_count != len(values):
             raise ProgrammingError("wrong number of parameters")

--- a/pycubrid/cursor.py
+++ b/pycubrid/cursor.py
@@ -44,6 +44,79 @@ def _extract_first_keyword(sql: str) -> str:
     return stripped.split(None, 1)[0].upper()
 
 
+def _split_on_placeholders(sql: str) -> list[str]:
+    """Split SQL on unquoted, uncommented `?` placeholders.
+
+    Tracks four states to skip `?` inside:
+    - Single-quoted strings (handles doubled '' escapes)
+    - Double-quoted identifiers
+    - Line comments (-- ... to EOL)
+    - Block comments (/* ... */)
+
+    Returns a list of N+1 parts where N is the number of real placeholders.
+    """
+    parts: list[str] = []
+    start = 0
+    i = 0
+    n = len(sql)
+
+    while i < n:
+        c = sql[i]
+
+        if c == "'":
+            # Single-quoted string: advance past closing quote
+            i += 1
+            while i < n:
+                if sql[i] == "'":
+                    i += 1
+                    if i < n and sql[i] == "'":
+                        # Doubled quote escape ''
+                        i += 1
+                    else:
+                        break
+                else:
+                    i += 1
+
+        elif c == '"':
+            # Double-quoted identifier: advance past closing quote
+            i += 1
+            while i < n:
+                if sql[i] == '"':
+                    i += 1
+                    if i < n and sql[i] == '"':
+                        i += 1
+                    else:
+                        break
+                else:
+                    i += 1
+
+        elif c == '-' and i + 1 < n and sql[i + 1] == '-':
+            # Line comment: skip to end of line
+            i += 2
+            while i < n and sql[i] != '\n':
+                i += 1
+
+        elif c == '/' and i + 1 < n and sql[i + 1] == '*':
+            # Block comment: skip to */
+            i += 2
+            while i < n:
+                if sql[i] == '*' and i + 1 < n and sql[i + 1] == '/':
+                    i += 2
+                    break
+                i += 1
+
+        elif c == '?':
+            # Real placeholder found
+            parts.append(sql[start:i])
+            i += 1
+            start = i
+
+        else:
+            i += 1
+
+    parts.append(sql[start:])
+    return parts
+
 class Cursor:
     """Database cursor implementing the DB-API 2.0 cursor interface."""
 
@@ -409,7 +482,7 @@ class Cursor:
         else:
             raise ProgrammingError("parameters must be a sequence")
 
-        parts = operation.split("?")
+        parts = _split_on_placeholders(operation)
         placeholder_count = len(parts) - 1
         if placeholder_count != len(values):
             raise ProgrammingError("wrong number of parameters")

--- a/tests/test_split_placeholders.py
+++ b/tests/test_split_placeholders.py
@@ -71,3 +71,85 @@ class TestSplitOnPlaceholders:
     def test_unterminated_block_comment(self):
         parts = _split_on_placeholders("/* unterminated SELECT ? FROM t")
         assert len(parts) == 1  # ? is inside comment, no placeholder
+
+
+class TestBindParametersIntegration:
+    """End-to-end _bind_parameters tests through Cursor path."""
+
+    def test_bind_skips_quoted_question_mark(self):
+        """Verify full bind path handles ? in string literals."""
+        from unittest.mock import MagicMock, patch
+        from pycubrid.cursor import Cursor
+
+        conn = MagicMock()
+        conn._no_backslash_escapes = False
+        conn._decode_collections = False
+        conn._json_deserializer = None
+        conn._fetch_size = 100
+        conn._timing = None
+        cur = Cursor(conn)
+
+        result = cur._bind_parameters(
+            "SELECT * FROM t WHERE name = 'what?' AND id = ?", [42]
+        )
+        assert result == "SELECT * FROM t WHERE name = 'what?' AND id = 42"
+
+    def test_bind_multiple_with_comments(self):
+        from unittest.mock import MagicMock
+        from pycubrid.cursor import Cursor
+
+        conn = MagicMock()
+        conn._no_backslash_escapes = False
+        conn._decode_collections = False
+        conn._json_deserializer = None
+        conn._fetch_size = 100
+        conn._timing = None
+        cur = Cursor(conn)
+
+        result = cur._bind_parameters(
+            "/* hint? */ INSERT INTO t (a, b) VALUES (?, ?)", ["hello", 99]
+        )
+        assert "hint?" in result
+        assert "'hello'" in result
+        assert "99" in result
+
+    def test_bind_wrong_count_with_quoted_question(self):
+        from unittest.mock import MagicMock
+        from pycubrid.cursor import Cursor
+        from pycubrid.exceptions import ProgrammingError
+
+        conn = MagicMock()
+        conn._no_backslash_escapes = False
+        conn._decode_collections = False
+        conn._json_deserializer = None
+        conn._fetch_size = 100
+        conn._timing = None
+        cur = Cursor(conn)
+
+        import pytest
+        # 'what?' doesn't count as placeholder, so only 1 real placeholder
+        with pytest.raises(ProgrammingError):
+            cur._bind_parameters(
+                "SELECT * FROM t WHERE name = 'what?' AND id = ?", [1, 2]
+            )
+
+
+class TestAsyncBindParity:
+    """Verify async cursor uses same placeholder logic."""
+
+    def test_async_bind_skips_quoted_question(self):
+        from unittest.mock import MagicMock, AsyncMock
+        from pycubrid.aio.cursor import AsyncCursor
+
+        conn = MagicMock()
+        conn._no_backslash_escapes = False
+        conn._decode_collections = False
+        conn._json_deserializer = None
+        conn._fetch_size = 100
+        conn._timing = None
+        cur = AsyncCursor(conn)
+
+        result = cur._bind_parameters(
+            "SELECT * FROM t WHERE name = 'what?' AND id = ?", [42]
+        )
+        assert result == "SELECT * FROM t WHERE name = 'what?' AND id = 42"

--- a/tests/test_split_placeholders.py
+++ b/tests/test_split_placeholders.py
@@ -1,0 +1,73 @@
+"""Tests for _split_on_placeholders() safe parameter binding."""
+
+from __future__ import annotations
+
+import pytest
+
+from pycubrid.cursor import _split_on_placeholders
+
+
+class TestSplitOnPlaceholders:
+    """Verify ? splitting respects quotes and comments."""
+
+    def test_simple(self):
+        assert _split_on_placeholders("SELECT * FROM t WHERE id = ?") == [
+            "SELECT * FROM t WHERE id = ", ""
+        ]
+
+    def test_multiple_placeholders(self):
+        assert _split_on_placeholders("INSERT INTO t (a, b) VALUES (?, ?)") == [
+            "INSERT INTO t (a, b) VALUES (", ", ", ")"
+        ]
+
+    def test_no_placeholders(self):
+        assert _split_on_placeholders("SELECT 1") == ["SELECT 1"]
+
+    def test_question_in_single_quoted_string(self):
+        parts = _split_on_placeholders("SELECT * FROM t WHERE name = 'what?' AND id = ?")
+        assert len(parts) == 2  # only 1 real placeholder
+        assert "what?" in parts[0]
+
+    def test_doubled_quote_escape(self):
+        parts = _split_on_placeholders("SELECT * FROM t WHERE name = 'it''s a question?' AND id = ?")
+        assert len(parts) == 2
+        assert "it''s a question?" in parts[0]
+
+    def test_question_in_double_quoted_identifier(self):
+        parts = _split_on_placeholders('SELECT "col?" FROM t WHERE id = ?')
+        assert len(parts) == 2
+        assert 'col?' in parts[0]
+
+    def test_question_in_line_comment(self):
+        parts = _split_on_placeholders("-- why?\nSELECT * FROM t WHERE id = ?")
+        assert len(parts) == 2
+        assert "why?" in parts[0]
+
+    def test_question_in_block_comment(self):
+        parts = _split_on_placeholders("/* why? */ SELECT * FROM t WHERE id = ?")
+        assert len(parts) == 2
+        assert "why?" in parts[0]
+
+    def test_mixed_comments_and_strings(self):
+        sql = "/* hint? */ SELECT * FROM t WHERE name = 'q?' AND -- comment?\nid = ?"
+        parts = _split_on_placeholders(sql)
+        assert len(parts) == 2
+
+    def test_optimizer_hint_with_question(self):
+        parts = _split_on_placeholders("/*+ hint? */ SELECT * FROM t WHERE id = ?")
+        assert len(parts) == 2
+
+    def test_empty_string(self):
+        assert _split_on_placeholders("") == [""]
+
+    def test_only_placeholder(self):
+        assert _split_on_placeholders("?") == ["", ""]
+
+    def test_unterminated_string_is_lenient(self):
+        # Malformed SQL - don't crash, let CUBRID reject it
+        parts = _split_on_placeholders("SELECT 'unterminated")
+        assert len(parts) == 1  # no placeholder found
+
+    def test_unterminated_block_comment(self):
+        parts = _split_on_placeholders("/* unterminated SELECT ? FROM t")
+        assert len(parts) == 1  # ? is inside comment, no placeholder


### PR DESCRIPTION
## Summary

- Replace naive `operation.split('?')` with `_split_on_placeholders()` state-machine tokenizer
- Skips `?` inside single-quoted strings (`''` escapes handled), double-quoted identifiers, line comments (`--`), and block comments (`/* */`)
- Shared between sync and async cursors
- 14 new targeted tests covering all edge cases

## Testing

848 tests pass (14 new + all existing).

Fixes #112