### PR TITLE
ci: add ci-gate job requiring all checks to pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
         run: |
           python -m pytest tests/ \
             --ignore=tests/test_integration.py \
+            --ignore=tests/test_parity_integration.py \
             -v --tb=short \
             --cov=pycubrid \
             --cov-report=term-missing \
@@ -156,7 +157,7 @@ jobs:
         env:
           CUBRID_TEST_URL: "cubrid://dba@localhost:33000/testdb"
         run: |
-          python -m pytest tests/test_integration.py -v --tb=short
+          python -m pytest tests/test_*integration*.py -v --tb=short
 
   ci-gate:
     name: CI Gate (all checks must pass)
@@ -172,6 +173,10 @@ jobs:
           fi
           if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
             echo '::error::One or more required jobs were cancelled'
+            exit 1
+          fi
+          if [[ "${{ contains(needs.*.result, 'skipped') }}" == "true" ]]; then
+            echo '::error::One or more required jobs were skipped'
             exit 1
           fi
           echo 'All CI checks passed ✓'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,3 +157,21 @@ jobs:
           CUBRID_TEST_URL: "cubrid://dba@localhost:33000/testdb"
         run: |
           python -m pytest tests/test_integration.py -v --tb=short
+
+  ci-gate:
+    name: CI Gate (all checks must pass)
+    if: always()
+    needs: [version-check, lint, offline-tests, packaging-smoke-test, integration-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check job results
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo '::error::One or more required jobs failed'
+            exit 1
+          fi
+          if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo '::error::One or more required jobs were cancelled'
+            exit 1
+          fi
+          echo 'All CI checks passed ✓'


### PR DESCRIPTION
## Summary
- Adds a `ci-gate` job that aggregates all CI jobs (version-check, lint, offline-tests, packaging-smoke-test, integration-tests)
- Fails if any upstream job fails or is cancelled
- Enables branch protection to require a single `ci-gate` status check, ensuring integration tests are mandatory for merge

Closes #113