### PR TITLE
fix: narrow broad exception in SSL socket wrapping

### DIFF
--- a/pycubrid/connection.py
+++ b/pycubrid/connection.py
@@ -405,7 +405,7 @@ class Connection:
         if ssl_context is not None:
             try:
                 sock = ssl_context.wrap_socket(sock, server_hostname=host)
-            except Exception:
+            except (OSError, ssl_module.SSLError):
                 sock.close()
                 raise
         return sock


### PR DESCRIPTION
## Summary
- Narrows the only actionable broad `except Exception` (SSL wrap in `_connect_tcp`) to `(OSError, ssl_module.SSLError)`
- The `close()`/cleanup handlers at lines 200, 207, and async equivalents are intentionally broad (best-effort cleanup must never propagate) — left as-is with existing `# nosec`/`# noqa` annotations

Closes #115