### PR TITLE
feat: expose per-cursor fetch_size property

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ marketers = cur.fetchall()
 - **Iterator protocol** — iterate over cursor results with `for row in cursor`
 - **Context managers** — `with` statements for both connections and cursors
 - **Async support** — `pycubrid.aio.connect()` with `AsyncConnection` and `AsyncCursor` for asyncio event loops
+- **Per-cursor fetch size** — `cursor.fetch_size` property to tune server-side fetch batch size per cursor
 
 ## Supported CUBRID Versions
 

--- a/pycubrid/aio/cursor.py
+++ b/pycubrid/aio/cursor.py
@@ -78,8 +78,8 @@ class AsyncCursor:
     @fetch_size.setter
     def fetch_size(self, value: int) -> None:
         """Set the server-side fetch batch size for this cursor."""
-        if value < 1:
-            raise ProgrammingError("fetch_size must be greater than zero")
+        if type(value) is not int or value < 1:
+            raise ProgrammingError("fetch_size must be an integer >= 1")
         self._fetch_size = value
 
     async def close(self) -> None:

--- a/pycubrid/aio/cursor.py
+++ b/pycubrid/aio/cursor.py
@@ -70,6 +70,18 @@ class AsyncCursor:
             raise ProgrammingError("arraysize must be greater than zero")
         self._arraysize = value
 
+    @property
+    def fetch_size(self) -> int:
+        """Return the server-side fetch batch size for this cursor."""
+        return self._fetch_size
+
+    @fetch_size.setter
+    def fetch_size(self, value: int) -> None:
+        """Set the server-side fetch batch size for this cursor."""
+        if value < 1:
+            raise ProgrammingError("fetch_size must be greater than zero")
+        self._fetch_size = value
+
     async def close(self) -> None:
         if self._closed:
             return

--- a/pycubrid/cursor.py
+++ b/pycubrid/cursor.py
@@ -85,6 +85,26 @@ class Cursor:
             raise ProgrammingError("arraysize must be greater than zero")
         self._arraysize = value
 
+    @property
+    def fetch_size(self) -> int:
+        """Return the server-side fetch batch size for this cursor.
+
+        This controls how many rows are requested from the CAS broker per
+        network round-trip.  Defaults to the connection-level setting.
+        """
+        return self._fetch_size
+
+    @fetch_size.setter
+    def fetch_size(self, value: int) -> None:
+        """Set the server-side fetch batch size for this cursor.
+
+        Args:
+            value: Number of rows per server fetch (must be >= 1).
+        """
+        if value < 1:
+            raise ProgrammingError("fetch_size must be greater than zero")
+        self._fetch_size = value
+
     def close(self) -> None:
         """Close the cursor and release the active query handle if present."""
         if self._closed:

--- a/pycubrid/cursor.py
+++ b/pycubrid/cursor.py
@@ -101,8 +101,8 @@ class Cursor:
         Args:
             value: Number of rows per server fetch (must be >= 1).
         """
-        if value < 1:
-            raise ProgrammingError("fetch_size must be greater than zero")
+        if type(value) is not int or value < 1:
+            raise ProgrammingError("fetch_size must be an integer >= 1")
         self._fetch_size = value
 
     def close(self) -> None:

--- a/tests/test_fetch_size.py
+++ b/tests/test_fetch_size.py
@@ -41,7 +41,7 @@ def test_fetch_size_zero_raises():
     """fetch_size < 1 raises ProgrammingError."""
     conn = _make_connection()
     cur = Cursor(conn)
-    with pytest.raises(ProgrammingError, match="fetch_size must be greater than zero"):
+    with pytest.raises(ProgrammingError, match="fetch_size must be an integer >= 1"):
         cur.fetch_size = 0
 
 
@@ -49,5 +49,63 @@ def test_fetch_size_negative_raises():
     """Negative fetch_size raises ProgrammingError."""
     conn = _make_connection()
     cur = Cursor(conn)
-    with pytest.raises(ProgrammingError, match="fetch_size must be greater than zero"):
+    with pytest.raises(ProgrammingError, match="fetch_size must be an integer >= 1"):
         cur.fetch_size = -1
+
+
+def test_fetch_size_non_int_raises():
+    """Non-integer fetch_size raises ProgrammingError."""
+    conn = _make_connection()
+    cur = Cursor(conn)
+    with pytest.raises(ProgrammingError, match="fetch_size must be an integer >= 1"):
+        cur.fetch_size = 1.5
+    with pytest.raises(ProgrammingError, match="fetch_size must be an integer >= 1"):
+        cur.fetch_size = "10"
+
+
+# ---------------------------------------------------------------------------
+# AsyncCursor tests
+# ---------------------------------------------------------------------------
+
+
+def _make_async_connection(fetch_size: int = 100) -> MagicMock:
+    conn = MagicMock()
+    conn._fetch_size = fetch_size
+    conn._timing = None
+    conn._cursors = set()
+    conn._decode_collections = False
+    conn._json_deserializer = None
+    conn._no_backslash_escapes = False
+    conn._connected = True
+    return conn
+
+
+def test_async_fetch_size_default():
+    """AsyncCursor fetch_size defaults to connection-level value."""
+    from pycubrid.aio.cursor import AsyncCursor
+
+    conn = _make_async_connection(fetch_size=300)
+    cur = AsyncCursor(conn)
+    assert cur.fetch_size == 300
+
+
+def test_async_fetch_size_settable():
+    """AsyncCursor fetch_size can be overridden."""
+    from pycubrid.aio.cursor import AsyncCursor
+
+    conn = _make_async_connection()
+    cur = AsyncCursor(conn)
+    cur.fetch_size = 42
+    assert cur.fetch_size == 42
+
+
+def test_async_fetch_size_validation():
+    """AsyncCursor fetch_size rejects invalid values."""
+    from pycubrid.aio.cursor import AsyncCursor
+
+    conn = _make_async_connection()
+    cur = AsyncCursor(conn)
+    with pytest.raises(ProgrammingError, match="fetch_size must be an integer >= 1"):
+        cur.fetch_size = 0
+    with pytest.raises(ProgrammingError, match="fetch_size must be an integer >= 1"):
+        cur.fetch_size = 2.5

--- a/tests/test_fetch_size.py
+++ b/tests/test_fetch_size.py
@@ -1,0 +1,53 @@
+"""Tests for per-cursor fetch_size property."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from pycubrid.cursor import Cursor
+from pycubrid.exceptions import ProgrammingError
+
+
+def _make_connection(fetch_size: int = 100) -> MagicMock:
+    conn = MagicMock()
+    conn._fetch_size = fetch_size
+    conn._timing = None
+    conn._cursors = set()
+    conn._decode_collections = False
+    conn._json_deserializer = None
+    conn._no_backslash_escapes = False
+    conn._connected = True
+    return conn
+
+
+def test_fetch_size_default():
+    """fetch_size defaults to connection-level value."""
+    conn = _make_connection(fetch_size=200)
+    cur = Cursor(conn)
+    assert cur.fetch_size == 200
+
+
+def test_fetch_size_settable():
+    """fetch_size can be overridden per-cursor."""
+    conn = _make_connection()
+    cur = Cursor(conn)
+    cur.fetch_size = 500
+    assert cur.fetch_size == 500
+
+
+def test_fetch_size_zero_raises():
+    """fetch_size < 1 raises ProgrammingError."""
+    conn = _make_connection()
+    cur = Cursor(conn)
+    with pytest.raises(ProgrammingError, match="fetch_size must be greater than zero"):
+        cur.fetch_size = 0
+
+
+def test_fetch_size_negative_raises():
+    """Negative fetch_size raises ProgrammingError."""
+    conn = _make_connection()
+    cur = Cursor(conn)
+    with pytest.raises(ProgrammingError, match="fetch_size must be greater than zero"):
+        cur.fetch_size = -1


### PR DESCRIPTION
## Summary
- Adds `fetch_size` property (getter + setter) to both `Cursor` and `AsyncCursor`
- Validates value >= 1, raises `ProgrammingError` otherwise
- Defaults to connection-level `_fetch_size` (backward compatible)
- Includes 4 unit tests

Closes #114