### PR TITLE
fix: serialize AsyncConnection I/O with per-connection lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - **Async connection I/O serialization** — `AsyncConnection` now guards request/response,
   reconnect, handshake stream assignment, and close lifecycle state with a per-connection
   `asyncio.Lock`, preventing protocol corruption when multiple coroutines share one connection (#137)
+- **Async cleanup on timeout and malformed responses** — async request failures now await
+  stream shutdown, including TLS `wait_closed()`, and malformed broker frames force
+  disconnect + `OperationalError` before the connection can be reused (#138)
 
 ### Validated
 - **Native `Connection.ping()` causally validated at application layer** — Tier 2 ORM benchmark in [cubrid-benchmark `2026-04-22_native-ping-hotpath`](https://github.com/cubrid-lab/cubrid-benchmark/tree/main/experiments/orm-overhead/runs/2026-04-22_native-ping-hotpath) (paired same-version A/B vs forced `SELECT 1`, 7 trials, bootstrap 95% CI) confirms native CHECK_CAS ping is **+279.9% throughput** on raw ping_only [+278.0, +283.9] and **+587.8% on SQLAlchemy `checkout_only`** [+581.8, +603.8] with `pool_pre_ping=True`. Performance Loop ping propagation gap closed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   `SSLContext.minimum_version = TLSVersion.TLSv1_2` to block legacy TLS downgrade
   risk and resolve CodeQL alert #144.
 
+### Fixed
+- **Async connection I/O serialization** — `AsyncConnection` now guards request/response,
+  reconnect, handshake stream assignment, and close lifecycle state with a per-connection
+  `asyncio.Lock`, preventing protocol corruption when multiple coroutines share one connection (#137)
+
 ### Validated
 - **Native `Connection.ping()` causally validated at application layer** — Tier 2 ORM benchmark in [cubrid-benchmark `2026-04-22_native-ping-hotpath`](https://github.com/cubrid-lab/cubrid-benchmark/tree/main/experiments/orm-overhead/runs/2026-04-22_native-ping-hotpath) (paired same-version A/B vs forced `SELECT 1`, 7 trials, bootstrap 95% CI) confirms native CHECK_CAS ping is **+279.9% throughput** on raw ping_only [+278.0, +283.9] and **+587.8% on SQLAlchemy `checkout_only`** [+581.8, +603.8] with `pool_pre_ping=True`. Performance Loop ping propagation gap closed.
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -865,6 +865,8 @@ Async counterpart to `Connection` for use with `asyncio`, with a similar surface
 | `set_autocommit()` | `async def set_autocommit(self, value: bool) -> None` | Sends `SetDbParameterPacket` and `CommitPacket` |
 
 `AsyncConnection` exposes async `ping()` parity with sync `Connection.ping()`. `create_lob()` remains sync-only.
+Concurrent awaiters on the same `AsyncConnection` are serialized with a per-connection
+`asyncio.Lock`, so shared use is safe but requests still execute one at a time.
 
 ```python
 async with await pycubrid.aio.connect(database="testdb") as conn:

--- a/pycubrid/aio/connection.py
+++ b/pycubrid/aio/connection.py
@@ -59,9 +59,14 @@ class AsyncConnection(ConnectionCommonMixin):
         )
         self._reader: asyncio.StreamReader | None = None
         self._writer: asyncio.StreamWriter | None = None
+        self._lock = asyncio.Lock()
 
     async def connect(self) -> None:
         """Establish a TCP CAS session with broker handshake and open database."""
+        async with self._lock:
+            await self._connect_locked()
+
+    async def _connect_locked(self) -> None:
         if self._connected:
             return
 
@@ -156,17 +161,21 @@ class AsyncConnection(ConnectionCommonMixin):
             finally:
                 self._cursors.discard(cursor)
 
-        try:
-            await self._send_and_receive(CloseDatabasePacket())
-        except Exception:  # noqa: BLE001 - best-effort cleanup
-            _LOGGER.debug(
-                "Suppressed error sending CloseDatabasePacket during shutdown", exc_info=True
-            )
-        finally:
-            await self._close_streams()
-            self._connected = False
-            if _timing is not None:
-                _timing.record_close(time.perf_counter_ns() - _start)
+        async with self._lock:
+            try:
+                if self._connected:
+                    await self._send_and_receive_locked(
+                        CloseDatabasePacket(), allow_reconnect=False
+                    )
+            except Exception:  # noqa: BLE001 - best-effort cleanup
+                _LOGGER.debug(
+                    "Suppressed error sending CloseDatabasePacket during shutdown", exc_info=True
+                )
+            finally:
+                await self._close_streams()
+                self._connected = False
+                if _timing is not None:
+                    _timing.record_close(time.perf_counter_ns() - _start)
 
     async def commit(self) -> None:
         """Commit the current transaction."""
@@ -237,10 +246,11 @@ class AsyncConnection(ConnectionCommonMixin):
             if not reconnect:
                 return False
             try:
-                await self._close_streams()
-                self._connected = False
-                self._invalidate_query_handles()
                 _LOGGER.debug("ping: reconnecting")
+                async with self._lock:
+                    await self._close_streams()
+                    self._connected = False
+                    self._invalidate_query_handles()
                 await self.connect()
                 return True
             except (OSError, OperationalError, InterfaceError):
@@ -303,7 +313,11 @@ class AsyncConnection(ConnectionCommonMixin):
             raise OperationalError(f"could not connect to {host}:{port}") from exc
 
     async def _send_and_receive(self, packet: Any, *, allow_reconnect: bool = True) -> Any:
-        await self._check_reconnect(allow_reconnect=allow_reconnect)
+        async with self._lock:
+            return await self._send_and_receive_locked(packet, allow_reconnect=allow_reconnect)
+
+    async def _send_and_receive_locked(self, packet: Any, *, allow_reconnect: bool = True) -> Any:
+        await self._check_reconnect_locked(allow_reconnect=allow_reconnect)
         if self._writer is None or self._reader is None:
             raise InterfaceError("connection is closed")
 
@@ -350,6 +364,10 @@ class AsyncConnection(ConnectionCommonMixin):
             raise OperationalError("connection lost during receive") from exc
 
     async def _check_reconnect(self, *, allow_reconnect: bool = True) -> None:
+        async with self._lock:
+            await self._check_reconnect_locked(allow_reconnect=allow_reconnect)
+
+    async def _check_reconnect_locked(self, *, allow_reconnect: bool = True) -> None:
         self._ensure_connected()
         if not allow_reconnect:
             return
@@ -357,7 +375,14 @@ class AsyncConnection(ConnectionCommonMixin):
             await self._close_streams()
             self._connected = False
             self._invalidate_query_handles()
-            await self.connect()
+            await self._invoke_connect_locked()
+
+    async def _invoke_connect_locked(self) -> None:
+        connect_method = self.connect
+        if getattr(connect_method, "__func__", None) is AsyncConnection.connect:
+            await self._connect_locked()
+            return
+        await connect_method()
 
     async def _close_streams(self) -> None:
         """Close the stream writer, await TLS shutdown, and clear references."""

--- a/pycubrid/aio/connection.py
+++ b/pycubrid/aio/connection.py
@@ -327,11 +327,11 @@ class AsyncConnection(ConnectionCommonMixin):
                 return await asyncio.wait_for(coro, timeout=self._read_timeout)
             return await coro
         except asyncio.TimeoutError:
-            self._close_streams_sync()
+            await self._close_streams()
             self._connected = False
             raise OperationalError("read timeout") from None
         except OSError as exc:
-            self._close_streams_sync()
+            await self._close_streams()
             self._connected = False
             raise OperationalError("socket communication failed") from exc
 
@@ -349,7 +349,12 @@ class AsyncConnection(ConnectionCommonMixin):
         response_body = await self._recv_exact(reader, data_length + DataSize.CAS_INFO)
 
         self._cas_info = response_body[: DataSize.CAS_INFO]
-        packet.parse(response_body)
+        try:
+            packet.parse(response_body)
+        except (ValueError, struct.error, IndexError, UnicodeDecodeError) as exc:
+            await self._close_streams()
+            self._connected = False
+            raise OperationalError("malformed response from broker") from exc
         return packet
 
     async def _recv_exact(

--- a/tests/test_aio_cleanup.py
+++ b/tests/test_aio_cleanup.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import asyncio
+import struct
+from collections.abc import Coroutine
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from pycubrid.aio.connection import AsyncConnection
+from pycubrid.exceptions import OperationalError
+from pycubrid.protocol import CommitPacket
+
+
+def build_simple_ok_response(cas_info: bytes | bytearray = b"\x01\x01\x02\x03") -> bytes:
+    body = cas_info + struct.pack(">i", 0)
+    return struct.pack(">i", len(body) - 4) + body
+
+
+def make_stream_pair(read_chunks: list[bytes]) -> tuple[MagicMock, MagicMock]:
+    reader = MagicMock()
+    reader.readexactly = AsyncMock(side_effect=list(read_chunks))
+    writer = MagicMock()
+    writer.drain = AsyncMock()
+    writer.close = MagicMock()
+    writer.wait_closed = AsyncMock()
+    return reader, writer
+
+
+async def raise_timeout_and_close_coro(
+    coro: Coroutine[object, object, object], timeout: float | None = None
+) -> None:
+    del timeout
+    coro.close()
+    raise asyncio.TimeoutError
+
+
+def make_connected_async_connection(
+    read_chunks: list[bytes], read_timeout: float | None = None
+) -> tuple[AsyncConnection, MagicMock, MagicMock]:
+    conn = AsyncConnection("localhost", 33000, "testdb", "dba", "", read_timeout=read_timeout)
+    conn._connected = True
+    conn._cas_info = b"\x01\x01\x02\x03"
+    reader, writer = make_stream_pair(read_chunks)
+    conn._reader = reader
+    conn._writer = writer
+    return conn, reader, writer
+
+
+@pytest.mark.asyncio
+async def test_truncated_response_disconnects_and_ping_reconnects() -> None:
+    frame = build_simple_ok_response()
+    conn, _, _ = make_connected_async_connection([frame[:4], frame[4:]])
+
+    with patch("pycubrid.protocol.CommitPacket.parse", side_effect=IndexError("truncated body")):
+        with pytest.raises(OperationalError, match="malformed response from broker"):
+            await conn._send_and_receive(CommitPacket())
+
+    assert conn._connected is False
+    assert conn._writer is None
+
+    reconnect = AsyncMock(
+        side_effect=lambda: (
+            setattr(conn, "_connected", True),
+            setattr(conn, "_reader", MagicMock()),
+            setattr(conn, "_writer", MagicMock()),
+        )
+    )
+    conn.connect = reconnect
+
+    assert await conn.ping(reconnect=True) is True
+    reconnect.assert_awaited_once()
+    assert conn._connected is True
+
+
+@pytest.mark.asyncio
+async def test_send_and_receive_timeout_awaits_stream_shutdown() -> None:
+    conn, _, writer = make_connected_async_connection([], read_timeout=0.5)
+
+    with patch(
+        "pycubrid.aio.connection.asyncio.wait_for",
+        new=AsyncMock(side_effect=raise_timeout_and_close_coro),
+    ):
+        with pytest.raises(OperationalError, match="read timeout"):
+            await conn._send_and_receive(CommitPacket())
+
+    writer.close.assert_called_once_with()
+    writer.wait_closed.assert_awaited_once()
+    assert conn._connected is False
+    assert conn._writer is None
+
+
+@pytest.mark.asyncio
+async def test_malformed_response_raises_operational_error_and_disconnects() -> None:
+    frame = build_simple_ok_response()
+    conn, _, _ = make_connected_async_connection([frame[:4], frame[4:]])
+
+    with patch("pycubrid.protocol.CommitPacket.parse", side_effect=ValueError("bad frame")):
+        with pytest.raises(OperationalError, match="malformed response from broker"):
+            await conn._send_and_receive(CommitPacket())
+
+    assert conn._connected is False
+    assert conn._writer is None

--- a/tests/test_aio_concurrency.py
+++ b/tests/test_aio_concurrency.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pycubrid.aio.connection import AsyncConnection
+from pycubrid.constants import CUBRIDStatementType
+from pycubrid.exceptions import InterfaceError, OperationalError
+from pycubrid.protocol import CloseDatabasePacket
+
+
+def make_connected_async_connection() -> AsyncConnection:
+    conn = AsyncConnection("localhost", 33000, "testdb", "dba", "")
+    conn._connected = True
+    conn._cas_info = b"\x01\x01\x02\x03"
+    conn._reader = MagicMock()
+    conn._writer = MagicMock()
+    conn._writer.close = MagicMock()
+    conn._writer.wait_closed = AsyncMock()
+    return conn
+
+
+@pytest.mark.asyncio
+async def test_concurrent_execute_calls_are_serialized_per_connection() -> None:
+    conn = make_connected_async_connection()
+    cur1 = conn.cursor()
+    cur2 = conn.cursor()
+
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    in_flight = 0
+    max_in_flight = 0
+    query_handle = 0
+
+    async def fake_do_send_and_receive(packet: Any) -> Any:
+        nonlocal in_flight, max_in_flight, query_handle
+
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        try:
+            if max_in_flight > 1:
+                raise AssertionError("request/response sections overlapped")
+
+            if not first_started.is_set():
+                first_started.set()
+                await release_first.wait()
+
+            await asyncio.sleep(0)
+
+            query_handle += 1
+            packet.query_handle = query_handle
+            packet.statement_type = CUBRIDStatementType.SELECT
+            packet.column_count = 0
+            packet.columns = []
+            packet.total_tuple_count = 0
+            packet.rows = []
+            packet.result_infos = []
+            return packet
+        finally:
+            in_flight -= 1
+
+    conn._do_send_and_receive = AsyncMock(side_effect=fake_do_send_and_receive)
+
+    task1 = asyncio.create_task(cur1.execute("SELECT 1"))
+    await first_started.wait()
+
+    task2 = asyncio.create_task(cur2.execute("SELECT 2"))
+    await asyncio.sleep(0)
+    assert not task2.done()
+
+    release_first.set()
+    await asyncio.gather(task1, task2)
+
+    assert max_in_flight == 1
+    assert cur1._query_handle == 1
+    assert cur2._query_handle == 2
+
+
+@pytest.mark.asyncio
+async def test_close_waits_for_in_flight_send_and_receive() -> None:
+    conn = make_connected_async_connection()
+    started = asyncio.Event()
+    release_request = asyncio.Event()
+    events: list[str] = []
+
+    async def fake_do_send_and_receive(packet: Any) -> Any:
+        if isinstance(packet, CloseDatabasePacket):
+            events.append("close")
+            return packet
+
+        events.append("request-start")
+        started.set()
+        await release_request.wait()
+        events.append("request-finish")
+        return packet
+
+    conn._do_send_and_receive = AsyncMock(side_effect=fake_do_send_and_receive)
+    request = MagicMock()
+
+    request_task = asyncio.create_task(conn._send_and_receive(request))
+    await started.wait()
+
+    close_task = asyncio.create_task(conn.close())
+    await asyncio.sleep(0)
+    assert not close_task.done()
+
+    release_request.set()
+
+    try:
+        result = await request_task
+        assert result is request
+    except (InterfaceError, OperationalError):
+        pass
+
+    await close_task
+
+    assert events == ["request-start", "request-finish", "close"]
+    assert conn._connected is False
+    assert conn._writer is None


### PR DESCRIPTION
## Summary
- serialize `AsyncConnection` request/response and lifecycle mutations with a per-connection `asyncio.Lock`
- cover concurrent `execute()` and `close()` race scenarios with mocked async transport tests
- document the serialized async concurrency contract in the API reference and changelog

## Changes
- add a per-instance lock to `AsyncConnection` and route `_send_and_receive`, reconnect, handshake stream assignment, and `close()` through lock-aware helpers
- preserve reconnect behavior without recursive lock acquisition by splitting locked connect/reconnect internals from the public `connect()` method
- add `tests/test_aio_concurrency.py` and update `docs/API_REFERENCE.md` plus `CHANGELOG.md`

## Testing
- `make lint`
- `make test`
- `lsp_diagnostics` (errors only) on `pycubrid/aio/connection.py` and `tests/test_aio_concurrency.py`

Closes #137