### PR TITLE
fix: clean up async connection on timeout and malformed responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - **Async connection I/O serialization** — `AsyncConnection` now guards request/response,
   reconnect, handshake stream assignment, and close lifecycle state with a per-connection
   `asyncio.Lock`, preventing protocol corruption when multiple coroutines share one connection (#137)
+- **Async cleanup on timeout and malformed responses** — async request failures now await
+  stream shutdown, including TLS `wait_closed()`, and malformed broker frames force
+  disconnect + `OperationalError` before the connection can be reused (#138)
 
 ### Validated
 - **Native `Connection.ping()` causally validated at application layer** — Tier 2 ORM benchmark in [cubrid-benchmark `2026-04-22_native-ping-hotpath`](https://github.com/cubrid-lab/cubrid-benchmark/tree/main/experiments/orm-overhead/runs/2026-04-22_native-ping-hotpath) (paired same-version A/B vs forced `SELECT 1`, 7 trials, bootstrap 95% CI) confirms native CHECK_CAS ping is **+279.9% throughput** on raw ping_only [+278.0, +283.9] and **+587.8% on SQLAlchemy `checkout_only`** [+581.8, +603.8] with `pool_pre_ping=True`. Performance Loop ping propagation gap closed.

--- a/pycubrid/aio/connection.py
+++ b/pycubrid/aio/connection.py
@@ -327,11 +327,11 @@ class AsyncConnection(ConnectionCommonMixin):
                 return await asyncio.wait_for(coro, timeout=self._read_timeout)
             return await coro
         except asyncio.TimeoutError:
-            self._close_streams_sync()
+            await self._close_streams()
             self._connected = False
             raise OperationalError("read timeout") from None
         except OSError as exc:
-            self._close_streams_sync()
+            await self._close_streams()
             self._connected = False
             raise OperationalError("socket communication failed") from exc
 
@@ -349,7 +349,12 @@ class AsyncConnection(ConnectionCommonMixin):
         response_body = await self._recv_exact(reader, data_length + DataSize.CAS_INFO)
 
         self._cas_info = response_body[: DataSize.CAS_INFO]
-        packet.parse(response_body)
+        try:
+            packet.parse(response_body)
+        except (ValueError, struct.error, IndexError, UnicodeDecodeError) as exc:
+            await self._close_streams()
+            self._connected = False
+            raise OperationalError("malformed response from broker") from exc
         return packet
 
     async def _recv_exact(

--- a/tests/test_aio_cleanup.py
+++ b/tests/test_aio_cleanup.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import asyncio
+import struct
+from collections.abc import Coroutine
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from pycubrid.aio.connection import AsyncConnection
+from pycubrid.exceptions import OperationalError
+from pycubrid.protocol import CommitPacket
+
+
+def build_simple_ok_response(cas_info: bytes | bytearray = b"\x01\x01\x02\x03") -> bytes:
+    body = cas_info + struct.pack(">i", 0)
+    return struct.pack(">i", len(body) - 4) + body
+
+
+def make_stream_pair(read_chunks: list[bytes]) -> tuple[MagicMock, MagicMock]:
+    reader = MagicMock()
+    reader.readexactly = AsyncMock(side_effect=list(read_chunks))
+    writer = MagicMock()
+    writer.drain = AsyncMock()
+    writer.close = MagicMock()
+    writer.wait_closed = AsyncMock()
+    return reader, writer
+
+
+async def raise_timeout_and_close_coro(
+    coro: Coroutine[object, object, object], timeout: float | None = None
+) -> None:
+    del timeout
+    coro.close()
+    raise asyncio.TimeoutError
+
+
+def make_connected_async_connection(
+    read_chunks: list[bytes], read_timeout: float | None = None
+) -> tuple[AsyncConnection, MagicMock, MagicMock]:
+    conn = AsyncConnection("localhost", 33000, "testdb", "dba", "", read_timeout=read_timeout)
+    conn._connected = True
+    conn._cas_info = b"\x01\x01\x02\x03"
+    reader, writer = make_stream_pair(read_chunks)
+    conn._reader = reader
+    conn._writer = writer
+    return conn, reader, writer
+
+
+@pytest.mark.asyncio
+async def test_truncated_response_disconnects_and_ping_reconnects() -> None:
+    frame = build_simple_ok_response()
+    conn, _, _ = make_connected_async_connection([frame[:4], frame[4:]])
+
+    with patch("pycubrid.protocol.CommitPacket.parse", side_effect=IndexError("truncated body")):
+        with pytest.raises(OperationalError, match="malformed response from broker"):
+            await conn._send_and_receive(CommitPacket())
+
+    assert conn._connected is False
+    assert conn._writer is None
+
+    reconnect = AsyncMock(
+        side_effect=lambda: (
+            setattr(conn, "_connected", True),
+            setattr(conn, "_reader", MagicMock()),
+            setattr(conn, "_writer", MagicMock()),
+        )
+    )
+    conn.connect = reconnect
+
+    assert await conn.ping(reconnect=True) is True
+    reconnect.assert_awaited_once()
+    assert conn._connected is True
+
+
+@pytest.mark.asyncio
+async def test_send_and_receive_timeout_awaits_stream_shutdown() -> None:
+    conn, _, writer = make_connected_async_connection([], read_timeout=0.5)
+
+    with patch(
+        "pycubrid.aio.connection.asyncio.wait_for",
+        new=AsyncMock(side_effect=raise_timeout_and_close_coro),
+    ):
+        with pytest.raises(OperationalError, match="read timeout"):
+            await conn._send_and_receive(CommitPacket())
+
+    writer.close.assert_called_once_with()
+    writer.wait_closed.assert_awaited_once()
+    assert conn._connected is False
+    assert conn._writer is None
+
+
+@pytest.mark.asyncio
+async def test_malformed_response_raises_operational_error_and_disconnects() -> None:
+    frame = build_simple_ok_response()
+    conn, _, _ = make_connected_async_connection([frame[:4], frame[4:]])
+
+    with patch("pycubrid.protocol.CommitPacket.parse", side_effect=ValueError("bad frame")):
+        with pytest.raises(OperationalError, match="malformed response from broker"):
+            await conn._send_and_receive(CommitPacket())
+
+    assert conn._connected is False
+    assert conn._writer is None


### PR DESCRIPTION
Closes #138

Stacked on #141. Will auto-rebase to main after #141 merges.

## Summary
- close async stream writers with awaited shutdown on timeout and transport failures so TLS cleanup completes
- treat malformed async broker frames as fatal, disconnect the session, and surface `OperationalError`
- cover malformed/truncated responses and timeout cleanup with new async regression tests

## Changes
- replaced `_close_streams_sync()` with `await self._close_streams()` in async timeout and `OSError` failure paths
- wrapped async response parsing failures (`ValueError`, `struct.error`, `IndexError`, `UnicodeDecodeError`) to close streams, mark the connection disconnected, and raise `OperationalError`
- added `tests/test_aio_cleanup.py` and updated `CHANGELOG.md` under `[Unreleased]`

## Testing
- make lint
- make test