### PR TITLE
test: add live async TLS integration coverage

### DIFF
--- a/.github/workflows/integration-full.yml
+++ b/.github/workflows/integration-full.yml
@@ -73,8 +73,4 @@ jobs:
         env:
           CUBRID_TEST_URL: "cubrid://dba@localhost:33000/testdb"
         run: |
-          if [ -f tests/test_integration.py ]; then
-            python -m pytest tests/test_integration.py -v --tb=short
-          else
-            echo "tests/test_integration.py not present yet; skipping integration suite."
-          fi
+          python -m pytest tests/test_*integration*.py -v --tb=short

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,21 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
-### Security
-- **Default TLS context now requires TLSv1.2+** — `resolve_ssl_context(True)` sets
-  `SSLContext.minimum_version = TLSVersion.TLSv1_2` to block legacy TLS downgrade
-  risk and resolve CodeQL alert #144.
-
-### Fixed
-- **Async connection I/O serialization** — `AsyncConnection` now guards request/response,
-  reconnect, handshake stream assignment, and close lifecycle state with a per-connection
-  `asyncio.Lock`, preventing protocol corruption when multiple coroutines share one connection (#137)
-- **Async cleanup on timeout and malformed responses** — async request failures now await
-  stream shutdown, including TLS `wait_closed()`, and malformed broker frames force
-  disconnect + `OperationalError` before the connection can be reused (#138)
-
 ### Tests
 - **Sync/async lifecycle parity coverage expanded** — integration parity tests now share adapter-driven scenarios and cover connection lifecycle APIs including `ping()`, CAS-inactive reconnect, auto-commit transitions, insert identity helpers, batch rowcount semantics, close ordering, and the explicit `AsyncConnection` `create_lob` `AttributeError` contract (closes #140)
+- **Async TLS integration coverage** — added `tests/test_aio_ssl_integration.py` with
+  live async TLS success/failure/reconnect/shutdown coverage gated behind an
+  explicitly configured TLS-enabled broker
 
 ### Validated
 - **Native `Connection.ping()` causally validated at application layer** — Tier 2 ORM benchmark in [cubrid-benchmark `2026-04-22_native-ping-hotpath`](https://github.com/cubrid-lab/cubrid-benchmark/tree/main/experiments/orm-overhead/runs/2026-04-22_native-ping-hotpath) (paired same-version A/B vs forced `SELECT 1`, 7 trials, bootstrap 95% CI) confirms native CHECK_CAS ping is **+279.9% throughput** on raw ping_only [+278.0, +283.9] and **+587.8% on SQLAlchemy `checkout_only`** [+581.8, +603.8] with `pool_pre_ping=True`. Performance Loop ping propagation gap closed.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -153,6 +153,39 @@ pytest tests/test_integration.py -v
 docker compose down -v
 ```
 
+#### Async TLS integration tests
+
+`tests/test_aio_ssl_integration.py` adds async TLS coverage for `pycubrid.aio`.
+The repository's default `docker-compose.yml` starts a plaintext broker only, so
+these tests are skipped unless you point them at a separate TLS-enabled broker.
+
+Export the normal integration variables plus these TLS overrides as needed:
+
+```bash
+export CUBRID_TLS_TEST_HOST=localhost
+export CUBRID_TLS_TEST_PORT=33001
+export CUBRID_TLS_TEST_DB=testdb
+export CUBRID_TLS_TEST_USER=dba
+export CUBRID_TLS_TEST_PASSWORD=
+
+# Optional: private CA bundle for ssl.SSLContext/load_verify_locations().
+export CUBRID_TLS_TEST_CA_FILE="$PWD/certs/ca.pem"
+
+# Optional: alternate reachable host/IP for hostname-mismatch coverage.
+export CUBRID_TLS_TEST_MISMATCH_HOST=127.0.0.1
+
+# If test_aio_ssl_connect_default_context uses a private CA, also point the
+# process default trust store at that CA before running pytest.
+export SSL_CERT_FILE="$CUBRID_TLS_TEST_CA_FILE"
+```
+
+Broker-side TLS must already be enabled (`SSL=ON` in `cubrid_broker.conf`) and
+the broker certificate must match `CUBRID_TLS_TEST_HOST`. Then run:
+
+```bash
+pytest tests/test_aio_ssl_integration.py -v
+```
+
 ### Code Coverage
 
 Current test metrics:

--- a/tests/test_aio_ssl_integration.py
+++ b/tests/test_aio_ssl_integration.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import ssl as ssl_module
+from functools import lru_cache
+
+import pytest
+
+import pycubrid
+import pycubrid.aio
+from pycubrid.aio.connection import AsyncConnection
+from pycubrid.exceptions import OperationalError
+
+TEST_HOST = os.environ.get("CUBRID_TEST_HOST", "localhost")
+TEST_PORT = int(os.environ.get("CUBRID_TEST_PORT", "33000"))
+TEST_DB = os.environ.get("CUBRID_TEST_DB", "testdb")
+TEST_USER = os.environ.get("CUBRID_TEST_USER", "dba")
+TEST_PASSWORD = os.environ.get("CUBRID_TEST_PASSWORD", "")
+
+TLS_HOST = os.environ.get("CUBRID_TLS_TEST_HOST", TEST_HOST)
+TLS_PORT = int(os.environ.get("CUBRID_TLS_TEST_PORT", str(TEST_PORT)))
+TLS_DB = os.environ.get("CUBRID_TLS_TEST_DB", TEST_DB)
+TLS_USER = os.environ.get("CUBRID_TLS_TEST_USER", TEST_USER)
+TLS_PASSWORD = os.environ.get("CUBRID_TLS_TEST_PASSWORD", TEST_PASSWORD)
+TLS_CA_FILE = os.environ.get("CUBRID_TLS_TEST_CA_FILE")
+TLS_MISMATCH_HOST = os.environ.get("CUBRID_TLS_TEST_MISMATCH_HOST")
+
+TLS_DEFAULT_REASON = (
+    "TLS-enabled CUBRID broker with default trust is not available; configure a trusted broker "
+    "via CUBRID_TLS_TEST_* or SSL_CERT_FILE"
+)
+TLS_CUSTOM_REASON = (
+    "TLS-enabled CUBRID broker is not available for custom SSLContext testing; configure "
+    "CUBRID_TLS_TEST_*"
+)
+TLS_MISMATCH_REASON = (
+    "Set CUBRID_TLS_TEST_MISMATCH_HOST to a reachable alternate host/IP that is not covered "
+    "by the broker certificate"
+)
+
+pytestmark = pytest.mark.integration
+
+
+def _custom_ssl_context() -> ssl_module.SSLContext:
+    context = ssl_module.create_default_context()
+    if TLS_CA_FILE:
+        context.load_verify_locations(cafile=TLS_CA_FILE)
+    return context
+
+
+def _can_connect_with_ssl(ssl_value: bool | ssl_module.SSLContext, *, host: str) -> bool:
+    try:
+        conn = pycubrid.connect(
+            host=host,
+            port=TLS_PORT,
+            database=TLS_DB,
+            user=TLS_USER,
+            password=TLS_PASSWORD,
+            connect_timeout=5,
+            read_timeout=5,
+            ssl=ssl_value,
+        )
+        cur = conn.cursor()
+        cur.execute("SELECT 1")
+        assert cur.fetchone() == (1,)
+        cur.close()
+        conn.close()
+        return True
+    except Exception:
+        return False
+
+
+@lru_cache(maxsize=None)
+def _can_connect_tls_default() -> bool:
+    return _can_connect_with_ssl(True, host=TLS_HOST)
+
+
+@lru_cache(maxsize=None)
+def _can_connect_tls_custom() -> bool:
+    return _can_connect_with_ssl(_custom_ssl_context(), host=TLS_HOST)
+
+
+async def _connect_async(
+    ssl_value: bool | ssl_module.SSLContext,
+    *,
+    host: str = TLS_HOST,
+) -> AsyncConnection:
+    return await pycubrid.aio.connect(
+        host=host,
+        port=TLS_PORT,
+        database=TLS_DB,
+        user=TLS_USER,
+        password=TLS_PASSWORD,
+        connect_timeout=5,
+        read_timeout=5,
+        ssl=ssl_value,
+    )
+
+
+async def _assert_select_one(conn: AsyncConnection) -> None:
+    cur = conn.cursor()
+    try:
+        await cur.execute("SELECT 1")
+        assert await cur.fetchone() == (1,)
+    finally:
+        await cur.close()
+
+
+def _assert_tls_transport(conn: AsyncConnection) -> None:
+    assert conn._writer is not None
+    assert conn._writer.get_extra_info("ssl_object") is not None
+
+
+def _require_mismatch_host() -> str:
+    assert TLS_MISMATCH_HOST is not None
+    return TLS_MISMATCH_HOST
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not _can_connect_tls_default(), reason=TLS_DEFAULT_REASON)
+async def test_aio_ssl_connect_default_context() -> None:
+    conn = await _connect_async(True)
+    try:
+        _assert_tls_transport(conn)
+        await _assert_select_one(conn)
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not _can_connect_tls_custom(), reason=TLS_CUSTOM_REASON)
+async def test_aio_ssl_connect_custom_context() -> None:
+    conn = await _connect_async(_custom_ssl_context())
+    try:
+        _assert_tls_transport(conn)
+        await _assert_select_one(conn)
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not _can_connect_tls_custom(), reason=TLS_CUSTOM_REASON)
+@pytest.mark.skipif(TLS_MISMATCH_HOST is None, reason=TLS_MISMATCH_REASON)
+async def test_aio_ssl_handshake_failure() -> None:
+    with pytest.raises(OperationalError) as excinfo:
+        await _connect_async(_custom_ssl_context(), host=_require_mismatch_host())
+
+    assert isinstance(excinfo.value.__cause__, ssl_module.SSLError)
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not _can_connect_tls_custom(), reason=TLS_CUSTOM_REASON)
+async def test_aio_ssl_reconnect_after_inactive() -> None:
+    conn = await _connect_async(_custom_ssl_context())
+    try:
+        original_writer = conn._writer
+        _assert_tls_transport(conn)
+
+        conn._cas_info = bytes([conn._CAS_INFO_STATUS_INACTIVE, *conn._cas_info[1:]])
+
+        assert await conn.ping(reconnect=True) is True
+        assert conn._writer is not None
+        assert conn._writer is not original_writer
+        _assert_tls_transport(conn)
+        await _assert_select_one(conn)
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not _can_connect_tls_custom(), reason=TLS_CUSTOM_REASON)
+async def test_aio_ssl_clean_shutdown() -> None:
+    conn = await _connect_async(_custom_ssl_context())
+
+    await asyncio.wait_for(conn.close(), timeout=5)
+
+    assert conn._reader is None
+    assert conn._writer is None


### PR DESCRIPTION
## Summary
- add async TLS integration coverage for `pycubrid.aio` with env-gated live broker probes
- document the TLS broker setup needed to run the new module locally
- ensure the full integration workflow discovers all `test_*integration*.py` modules

## Changes
- add `tests/test_aio_ssl_integration.py` for default/custom context success, handshake failure, reconnect-after-inactive, and clean shutdown coverage
- update `docs/DEVELOPMENT.md` with TLS broker environment variables and local run instructions
- update `.github/workflows/integration-full.yml` to collect the new integration module
- add an `[Unreleased]` changelog entry for the new async TLS coverage

## Testing
- `make lint`
- `make test` (828 passed, 27 skipped, coverage 96%)

Closes #139

## Follow-up note
- The repository's default Docker/CI broker is plaintext-only today, so the live TLS cases stay guarded by `skipif` until a TLS-enabled broker is provisioned for CI.