### PR TITLE
fix: set TLS minimum version to TLSv1.2 in default context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Security
+- **Default TLS context now requires TLSv1.2+** — `resolve_ssl_context(True)` sets
+  `SSLContext.minimum_version = TLSVersion.TLSv1_2` to block legacy TLS downgrade
+  risk and resolve CodeQL alert #144.
+
 ### Validated
 - **Native `Connection.ping()` causally validated at application layer** — Tier 2 ORM benchmark in [cubrid-benchmark `2026-04-22_native-ping-hotpath`](https://github.com/cubrid-lab/cubrid-benchmark/tree/main/experiments/orm-overhead/runs/2026-04-22_native-ping-hotpath) (paired same-version A/B vs forced `SELECT 1`, 7 trials, bootstrap 95% CI) confirms native CHECK_CAS ping is **+279.9% throughput** on raw ping_only [+278.0, +283.9] and **+587.8% on SQLAlchemy `checkout_only`** [+581.8, +603.8] with `pool_pre_ping=True`. Performance Loop ping propagation gap closed.
 

--- a/pycubrid/_connection_common.py
+++ b/pycubrid/_connection_common.py
@@ -34,7 +34,9 @@ def resolve_ssl_context(
         return None
     if isinstance(ssl_param, bool):
         if ssl_param:
-            return ssl_module.create_default_context()
+            ctx = ssl_module.create_default_context()
+            ctx.minimum_version = ssl_module.TLSVersion.TLSv1_2
+            return ctx
         return None
     if isinstance(ssl_param, ssl_module.SSLContext):
         return ssl_param

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -6,7 +6,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from pycubrid.connection import Connection, resolve_ssl_context
+from pycubrid._connection_common import resolve_ssl_context
+from pycubrid.connection import Connection
 
 
 def test_resolve_ssl_context_true_creates_default_context() -> None:
@@ -18,6 +19,8 @@ def test_resolve_ssl_context_true_creates_default_context() -> None:
         result = resolve_ssl_context(True)
 
     assert result is context
+    assert result is not None
+    assert result.minimum_version >= ssl_module.TLSVersion.TLSv1_2
     create_ctx.assert_called_once_with()
 
 
@@ -28,8 +31,10 @@ def test_resolve_ssl_context_false_and_none_disable_tls() -> None:
 
 def test_resolve_ssl_context_custom_context_is_reused() -> None:
     context = ssl_module.create_default_context()
+    context.minimum_version = ssl_module.TLSVersion.TLSv1
 
     assert resolve_ssl_context(context) is context
+    assert context.minimum_version == ssl_module.TLSVersion.TLSv1
 
 
 def test_resolve_ssl_context_invalid_value_raises_value_error() -> None:


### PR DESCRIPTION
## Summary
- Set the default SSL context minimum version to TLSv1.2 when `ssl=True`
- Add regression coverage for the default TLS context and preserve custom contexts
- Document the security fix in the unreleased changelog

## Verification
- `make lint`
- `make test` (828 passed, 22 skipped, 96.34% coverage)

Closes #144