### PR TITLE
test: expand sync/async parity for connection lifecycle APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   stream shutdown, including TLS `wait_closed()`, and malformed broker frames force
   disconnect + `OperationalError` before the connection can be reused (#138)
 
+### Tests
+- **Sync/async lifecycle parity coverage expanded** — integration parity tests now share adapter-driven scenarios and cover connection lifecycle APIs including `ping()`, CAS-inactive reconnect, auto-commit transitions, insert identity helpers, batch rowcount semantics, close ordering, and the documented async `create_lob()` gap (closes #140)
+
 ### Validated
 - **Native `Connection.ping()` causally validated at application layer** — Tier 2 ORM benchmark in [cubrid-benchmark `2026-04-22_native-ping-hotpath`](https://github.com/cubrid-lab/cubrid-benchmark/tree/main/experiments/orm-overhead/runs/2026-04-22_native-ping-hotpath) (paired same-version A/B vs forced `SELECT 1`, 7 trials, bootstrap 95% CI) confirms native CHECK_CAS ping is **+279.9% throughput** on raw ping_only [+278.0, +283.9] and **+587.8% on SQLAlchemy `checkout_only`** [+581.8, +603.8] with `pool_pre_ping=True`. Performance Loop ping propagation gap closed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   disconnect + `OperationalError` before the connection can be reused (#138)
 
 ### Tests
-- **Sync/async lifecycle parity coverage expanded** — integration parity tests now share adapter-driven scenarios and cover connection lifecycle APIs including `ping()`, CAS-inactive reconnect, auto-commit transitions, insert identity helpers, batch rowcount semantics, close ordering, and the documented async `create_lob()` gap (closes #140)
+- **Sync/async lifecycle parity coverage expanded** — integration parity tests now share adapter-driven scenarios and cover connection lifecycle APIs including `ping()`, CAS-inactive reconnect, auto-commit transitions, insert identity helpers, batch rowcount semantics, close ordering, and the explicit `AsyncConnection` `create_lob` `AttributeError` contract (closes #140)
 
 ### Validated
 - **Native `Connection.ping()` causally validated at application layer** — Tier 2 ORM benchmark in [cubrid-benchmark `2026-04-22_native-ping-hotpath`](https://github.com/cubrid-lab/cubrid-benchmark/tree/main/experiments/orm-overhead/runs/2026-04-22_native-ping-hotpath) (paired same-version A/B vs forced `SELECT 1`, 7 trials, bootstrap 95% CI) confirms native CHECK_CAS ping is **+279.9% throughput** on raw ping_only [+278.0, +283.9] and **+587.8% on SQLAlchemy `checkout_only`** [+581.8, +603.8] with `pool_pre_ping=True`. Performance Loop ping propagation gap closed.

--- a/tests/_parity_helpers.py
+++ b/tests/_parity_helpers.py
@@ -570,8 +570,9 @@ async def executemany_batch_semantics(
                 "UPDATE %s SET name = 'updated' WHERE id = 2" % table,
             ],
         )
+        batch_rowcount = cur.rowcount
         await adapter.execute(cur, "SELECT COUNT(*) FROM %s" % table)
-        return results, cur.rowcount, await adapter.fetchone(cur)
+        return results, batch_rowcount, await adapter.fetchone(cur)
     finally:
         try:
             await cleanup_table(adapter, conn, table)

--- a/tests/_parity_helpers.py
+++ b/tests/_parity_helpers.py
@@ -535,15 +535,17 @@ async def autocommit_transitions(adapter: ParityAdapter) -> tuple[bool, bool, bo
 async def insert_identity_values(adapter: ParityAdapter) -> tuple[int | None, str]:
     table = table_name("identity")
     conn = await adapter.connect()
-    await adapter.set_autocommit(conn, True)
+    await adapter.set_autocommit(conn, False)
     cur = adapter.cursor(conn)
     try:
         await adapter.execute(cur, "DROP TABLE IF EXISTS %s" % table)
         await adapter.execute(
             cur,
-            "CREATE TABLE %s (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(50))" % table,
+            "CREATE TABLE %s (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(50), val INT)"
+            % table,
         )
-        await adapter.execute(cur, "INSERT INTO %s (name) VALUES (?)" % table, ("alpha",))
+        await adapter.commit(conn)
+        await adapter.execute(cur, "INSERT INTO %s (name, val) VALUES (?, ?)" % table, ("alpha", 1))
         return adapter.lastrowid(cur), await adapter.get_last_insert_id(conn)
     finally:
         try:

--- a/tests/_parity_helpers.py
+++ b/tests/_parity_helpers.py
@@ -1,0 +1,592 @@
+"""Shared sync/async parity helpers for integration tests.
+
+The shared scenarios are async-first so pytest can drive one implementation
+against both adapters. The sync adapter uses thin async wrappers around direct
+calls because pycubrid connections/cursors are not thread-safe enough for
+``asyncio.to_thread()`` hopping between worker threads.
+"""
+
+# pyright: reportUnusedParameter=false, reportPrivateUsage=false, reportImplicitOverride=false, reportUnusedCallResult=false, reportAny=false
+
+from __future__ import annotations
+
+import os
+import socket
+import uuid
+from collections.abc import Callable, Sequence
+from typing import TypedDict
+
+import pycubrid
+import pycubrid.aio
+from pycubrid.aio.connection import AsyncConnection
+from pycubrid.aio.cursor import AsyncCursor
+from pycubrid.connection import Connection
+from pycubrid.cursor import Cursor
+
+JsonDeserializer = Callable[[str], object]
+Row = tuple[object, ...]
+
+
+class ConnectKwargs(TypedDict, total=False):
+    host: str
+    port: int
+    database: str
+    user: str
+    password: str
+    fetch_size: int
+    json_deserializer: JsonDeserializer
+
+
+TEST_HOST = os.environ.get("CUBRID_TEST_HOST", "localhost")
+TEST_PORT = int(os.environ.get("CUBRID_TEST_PORT", "33000"))
+TEST_DB = os.environ.get("CUBRID_TEST_DB", "testdb")
+TEST_USER = os.environ.get("CUBRID_TEST_USER", "dba")
+TEST_PASSWORD = os.environ.get("CUBRID_TEST_PASSWORD", "")
+
+
+def connect_kwargs(
+    *,
+    fetch_size: int | None = None,
+    json_deserializer: JsonDeserializer | None = None,
+) -> ConnectKwargs:
+    kwargs: ConnectKwargs = {
+        "host": TEST_HOST,
+        "port": TEST_PORT,
+        "database": TEST_DB,
+        "user": TEST_USER,
+        "password": TEST_PASSWORD,
+    }
+    if fetch_size is not None:
+        kwargs["fetch_size"] = fetch_size
+    if json_deserializer is not None:
+        kwargs["json_deserializer"] = json_deserializer
+    return kwargs
+
+
+def can_connect() -> bool:
+    try:
+        conn = pycubrid.connect(
+            host=TEST_HOST,
+            port=TEST_PORT,
+            database=TEST_DB,
+            user=TEST_USER,
+            password=TEST_PASSWORD,
+        )
+    except Exception:
+        return False
+    conn.close()
+    return True
+
+
+def table_name(prefix: str = "parity") -> str:
+    return "%s_%s" % (prefix, uuid.uuid4().hex[:8])
+
+
+class ParityAdapter:
+    kind: str = "base"
+
+    async def connect(
+        self,
+        *,
+        fetch_size: int | None = None,
+        json_deserializer: JsonDeserializer | None = None,
+    ) -> Connection | AsyncConnection:
+        raise NotImplementedError
+
+    async def close_connection(self, _conn: Connection | AsyncConnection) -> None:
+        raise NotImplementedError
+
+    def cursor(self, _conn: Connection | AsyncConnection) -> Cursor | AsyncCursor:
+        raise NotImplementedError
+
+    async def close_cursor(self, _cur: Cursor | AsyncCursor) -> None:
+        raise NotImplementedError
+
+    async def set_autocommit(self, _conn: Connection | AsyncConnection, _value: bool) -> None:
+        raise NotImplementedError
+
+    async def commit(self, _conn: Connection | AsyncConnection) -> None:
+        raise NotImplementedError
+
+    async def rollback(self, _conn: Connection | AsyncConnection) -> None:
+        raise NotImplementedError
+
+    async def ping(self, _conn: Connection | AsyncConnection, reconnect: bool) -> bool:
+        raise NotImplementedError
+
+    async def get_server_version(self, _conn: Connection | AsyncConnection) -> str:
+        raise NotImplementedError
+
+    async def get_last_insert_id(self, _conn: Connection | AsyncConnection) -> str:
+        raise NotImplementedError
+
+    async def execute(
+        self,
+        _cur: Cursor | AsyncCursor,
+        _operation: str,
+        _parameters: Sequence[object] | None = None,
+    ) -> None:
+        raise NotImplementedError
+
+    async def executemany(
+        self,
+        _cur: Cursor | AsyncCursor,
+        _operation: str,
+        _seq_of_parameters: Sequence[Sequence[object]],
+    ) -> None:
+        raise NotImplementedError
+
+    async def executemany_batch(
+        self,
+        _cur: Cursor | AsyncCursor,
+        _sql_list: list[str],
+    ) -> list[tuple[int, int]]:
+        raise NotImplementedError
+
+    async def fetchone(self, _cur: Cursor | AsyncCursor) -> Row | None:
+        raise NotImplementedError
+
+    async def fetchmany(self, _cur: Cursor | AsyncCursor, _size: int) -> list[Row]:
+        raise NotImplementedError
+
+    async def fetchall(self, _cur: Cursor | AsyncCursor) -> list[Row]:
+        raise NotImplementedError
+
+    async def drop_transport(self, _conn: Connection | AsyncConnection) -> None:
+        raise NotImplementedError
+
+    def autocommit_state(self, conn: Connection | AsyncConnection) -> bool:
+        return conn.autocommit
+
+    def lastrowid(self, cur: Cursor | AsyncCursor) -> int | None:
+        return cur.lastrowid
+
+    def mark_cas_inactive(self, conn: Connection | AsyncConnection) -> None:
+        conn._ensure_connected()
+        conn._cas_info = bytes([0]) + bytes(conn._cas_info[1:])
+
+    def transport_token(self, _conn: Connection | AsyncConnection) -> object | None:
+        raise NotImplementedError
+
+
+class SyncParityAdapter(ParityAdapter):
+    kind: str = "sync"
+
+    async def connect(
+        self,
+        *,
+        fetch_size: int | None = None,
+        json_deserializer: JsonDeserializer | None = None,
+    ) -> Connection:
+        return pycubrid.connect(
+            **connect_kwargs(fetch_size=fetch_size, json_deserializer=json_deserializer)
+        )
+
+    async def close_connection(self, conn: Connection | AsyncConnection) -> None:
+        assert isinstance(conn, Connection)
+        conn.close()
+
+    def cursor(self, conn: Connection | AsyncConnection) -> Cursor:
+        assert isinstance(conn, Connection)
+        return conn.cursor()
+
+    async def close_cursor(self, cur: Cursor | AsyncCursor) -> None:
+        assert isinstance(cur, Cursor)
+        cur.close()
+
+    async def set_autocommit(self, conn: Connection | AsyncConnection, value: bool) -> None:
+        assert isinstance(conn, Connection)
+        conn.autocommit = value
+
+    async def commit(self, conn: Connection | AsyncConnection) -> None:
+        assert isinstance(conn, Connection)
+        conn.commit()
+
+    async def rollback(self, conn: Connection | AsyncConnection) -> None:
+        assert isinstance(conn, Connection)
+        conn.rollback()
+
+    async def ping(self, conn: Connection | AsyncConnection, reconnect: bool) -> bool:
+        assert isinstance(conn, Connection)
+        return conn.ping(reconnect=reconnect)
+
+    async def get_server_version(self, conn: Connection | AsyncConnection) -> str:
+        assert isinstance(conn, Connection)
+        return conn.get_server_version()
+
+    async def get_last_insert_id(self, conn: Connection | AsyncConnection) -> str:
+        assert isinstance(conn, Connection)
+        return conn.get_last_insert_id()
+
+    async def execute(
+        self,
+        cur: Cursor | AsyncCursor,
+        operation: str,
+        parameters: Sequence[object] | None = None,
+    ) -> None:
+        assert isinstance(cur, Cursor)
+        if parameters is None:
+            cur.execute(operation)
+            return
+        cur.execute(operation, parameters)
+
+    async def executemany(
+        self,
+        cur: Cursor | AsyncCursor,
+        operation: str,
+        seq_of_parameters: Sequence[Sequence[object]],
+    ) -> None:
+        assert isinstance(cur, Cursor)
+        cur.executemany(operation, seq_of_parameters)
+
+    async def executemany_batch(
+        self,
+        cur: Cursor | AsyncCursor,
+        sql_list: list[str],
+    ) -> list[tuple[int, int]]:
+        assert isinstance(cur, Cursor)
+        return cur.executemany_batch(sql_list)
+
+    async def fetchone(self, cur: Cursor | AsyncCursor) -> Row | None:
+        assert isinstance(cur, Cursor)
+        return cur.fetchone()
+
+    async def fetchmany(self, cur: Cursor | AsyncCursor, size: int) -> list[Row]:
+        assert isinstance(cur, Cursor)
+        return cur.fetchmany(size)
+
+    async def fetchall(self, cur: Cursor | AsyncCursor) -> list[Row]:
+        assert isinstance(cur, Cursor)
+        return cur.fetchall()
+
+    async def drop_transport(self, conn: Connection | AsyncConnection) -> None:
+        assert isinstance(conn, Connection)
+        if conn._socket is None:
+            return
+        try:
+            conn._socket.shutdown(socket.SHUT_RDWR)
+        except OSError:
+            pass
+        conn._socket.close()
+        conn._socket = None
+
+    def transport_token(self, conn: Connection | AsyncConnection) -> object | None:
+        assert isinstance(conn, Connection)
+        return conn._socket
+
+
+class AsyncParityAdapter(ParityAdapter):
+    kind: str = "async"
+
+    async def connect(
+        self,
+        *,
+        fetch_size: int | None = None,
+        json_deserializer: JsonDeserializer | None = None,
+    ) -> AsyncConnection:
+        return await pycubrid.aio.connect(
+            **connect_kwargs(fetch_size=fetch_size, json_deserializer=json_deserializer)
+        )
+
+    async def close_connection(self, conn: Connection | AsyncConnection) -> None:
+        assert isinstance(conn, AsyncConnection)
+        await conn.close()
+
+    def cursor(self, conn: Connection | AsyncConnection) -> AsyncCursor:
+        assert isinstance(conn, AsyncConnection)
+        return conn.cursor()
+
+    async def close_cursor(self, cur: Cursor | AsyncCursor) -> None:
+        assert isinstance(cur, AsyncCursor)
+        await cur.close()
+
+    async def set_autocommit(self, conn: Connection | AsyncConnection, value: bool) -> None:
+        assert isinstance(conn, AsyncConnection)
+        await conn.set_autocommit(value)
+
+    async def commit(self, conn: Connection | AsyncConnection) -> None:
+        assert isinstance(conn, AsyncConnection)
+        await conn.commit()
+
+    async def rollback(self, conn: Connection | AsyncConnection) -> None:
+        assert isinstance(conn, AsyncConnection)
+        await conn.rollback()
+
+    async def ping(self, conn: Connection | AsyncConnection, reconnect: bool) -> bool:
+        assert isinstance(conn, AsyncConnection)
+        return await conn.ping(reconnect=reconnect)
+
+    async def get_server_version(self, conn: Connection | AsyncConnection) -> str:
+        assert isinstance(conn, AsyncConnection)
+        return await conn.get_server_version()
+
+    async def get_last_insert_id(self, conn: Connection | AsyncConnection) -> str:
+        assert isinstance(conn, AsyncConnection)
+        return await conn.get_last_insert_id()
+
+    async def execute(
+        self,
+        cur: Cursor | AsyncCursor,
+        operation: str,
+        parameters: Sequence[object] | None = None,
+    ) -> None:
+        assert isinstance(cur, AsyncCursor)
+        if parameters is None:
+            await cur.execute(operation)
+            return
+        await cur.execute(operation, parameters)
+
+    async def executemany(
+        self,
+        cur: Cursor | AsyncCursor,
+        operation: str,
+        seq_of_parameters: Sequence[Sequence[object]],
+    ) -> None:
+        assert isinstance(cur, AsyncCursor)
+        await cur.executemany(operation, seq_of_parameters)
+
+    async def executemany_batch(
+        self,
+        cur: Cursor | AsyncCursor,
+        sql_list: list[str],
+    ) -> list[tuple[int, int]]:
+        assert isinstance(cur, AsyncCursor)
+        return await cur.executemany_batch(sql_list)
+
+    async def fetchone(self, cur: Cursor | AsyncCursor) -> Row | None:
+        assert isinstance(cur, AsyncCursor)
+        return await cur.fetchone()
+
+    async def fetchmany(self, cur: Cursor | AsyncCursor, size: int) -> list[Row]:
+        assert isinstance(cur, AsyncCursor)
+        return await cur.fetchmany(size)
+
+    async def fetchall(self, cur: Cursor | AsyncCursor) -> list[Row]:
+        assert isinstance(cur, AsyncCursor)
+        return await cur.fetchall()
+
+    async def drop_transport(self, conn: Connection | AsyncConnection) -> None:
+        assert isinstance(conn, AsyncConnection)
+        if conn._writer is None:
+            return
+        conn._writer.close()
+        try:
+            await conn._writer.wait_closed()
+        except OSError:
+            pass
+        conn._writer = None
+        conn._reader = None
+
+    def transport_token(self, conn: Connection | AsyncConnection) -> object | None:
+        assert isinstance(conn, AsyncConnection)
+        return conn._writer
+
+
+ADAPTERS: tuple[ParityAdapter, ParityAdapter] = (SyncParityAdapter(), AsyncParityAdapter())
+
+
+async def cleanup_table(
+    adapter: ParityAdapter, conn: Connection | AsyncConnection, table: str
+) -> None:
+    cur = adapter.cursor(conn)
+    try:
+        await adapter.execute(cur, "DROP TABLE IF EXISTS %s" % table)
+        if not adapter.autocommit_state(conn):
+            await adapter.commit(conn)
+    finally:
+        await adapter.close_cursor(cur)
+
+
+async def select_round_trip(
+    adapter: ParityAdapter,
+    rows: Sequence[Sequence[object]],
+    *,
+    table_prefix: str,
+    table_definition: str = "(id INT, name VARCHAR(200), val DOUBLE)",
+    insert_sql: str | None = None,
+    select_sql: str | None = None,
+    autocommit: bool = False,
+    fetch_size: int | None = None,
+    json_deserializer: JsonDeserializer | None = None,
+) -> list[Row]:
+    table = table_name(table_prefix)
+    rendered_insert_sql = None if insert_sql is None else insert_sql.format(table=table)
+    rendered_select_sql = None if select_sql is None else select_sql.format(table=table)
+    conn = await adapter.connect(fetch_size=fetch_size, json_deserializer=json_deserializer)
+    await adapter.set_autocommit(conn, autocommit)
+    cur = adapter.cursor(conn)
+    try:
+        await adapter.execute(cur, "DROP TABLE IF EXISTS %s" % table)
+        await adapter.execute(cur, "CREATE TABLE %s %s" % (table, table_definition))
+        await adapter.executemany(
+            cur,
+            rendered_insert_sql or "INSERT INTO %s (id, name, val) VALUES (?, ?, ?)" % table,
+            rows,
+        )
+        if not autocommit:
+            await adapter.commit(conn)
+        await adapter.execute(
+            cur,
+            rendered_select_sql or "SELECT id, name, val FROM %s ORDER BY id" % table,
+        )
+        return await adapter.fetchall(cur)
+    finally:
+        try:
+            await cleanup_table(adapter, conn, table)
+        finally:
+            await adapter.close_connection(conn)
+
+
+async def rollback_rows(adapter: ParityAdapter) -> list[Row]:
+    table = table_name("rollback")
+    conn = await adapter.connect()
+    await adapter.set_autocommit(conn, False)
+    cur = adapter.cursor(conn)
+    try:
+        await adapter.execute(cur, "DROP TABLE IF EXISTS %s" % table)
+        await adapter.execute(cur, "CREATE TABLE %s (id INT)" % table)
+        await adapter.commit(conn)
+        await adapter.execute(cur, "INSERT INTO %s (id) VALUES (?)" % table, (999,))
+        await adapter.rollback(conn)
+        await adapter.execute(cur, "SELECT id FROM %s" % table)
+        return await adapter.fetchall(cur)
+    finally:
+        try:
+            await cleanup_table(adapter, conn, table)
+        finally:
+            await adapter.close_connection(conn)
+
+
+async def fetchmany_round_trip(adapter: ParityAdapter) -> tuple[list[Row], list[Row], list[Row]]:
+    table = table_name("fetchmany")
+    rows = [(index, "item_%d" % index, float(index)) for index in range(10)]
+    conn = await adapter.connect()
+    await adapter.set_autocommit(conn, True)
+    cur = adapter.cursor(conn)
+    try:
+        await adapter.execute(cur, "DROP TABLE IF EXISTS %s" % table)
+        await adapter.execute(
+            cur, "CREATE TABLE %s (id INT, name VARCHAR(100), val DOUBLE)" % table
+        )
+        await adapter.executemany(
+            cur, "INSERT INTO %s (id, name, val) VALUES (?, ?, ?)" % table, rows
+        )
+        await adapter.execute(cur, "SELECT id, name, val FROM %s ORDER BY id" % table)
+        batch_one = await adapter.fetchmany(cur, 3)
+        batch_two = await adapter.fetchmany(cur, 3)
+        remaining = await adapter.fetchall(cur)
+        return batch_one, batch_two, remaining
+    finally:
+        try:
+            await cleanup_table(adapter, conn, table)
+        finally:
+            await adapter.close_connection(conn)
+
+
+async def ping_after_drop(adapter: ParityAdapter, reconnect: bool) -> tuple[bool, Row | None]:
+    conn = await adapter.connect()
+    try:
+        await adapter.drop_transport(conn)
+        ping_result = await adapter.ping(conn, reconnect=reconnect)
+        if not reconnect:
+            return ping_result, None
+        cur = adapter.cursor(conn)
+        try:
+            await adapter.execute(cur, "SELECT 1")
+            return ping_result, await adapter.fetchone(cur)
+        finally:
+            await adapter.close_cursor(cur)
+    finally:
+        await adapter.close_connection(conn)
+
+
+async def reconnect_after_inactive_cas(adapter: ParityAdapter) -> tuple[bool, Row, str]:
+    conn = await adapter.connect()
+    before = adapter.transport_token(conn)
+    try:
+        adapter.mark_cas_inactive(conn)
+        version = await adapter.get_server_version(conn)
+        cur = adapter.cursor(conn)
+        try:
+            await adapter.execute(cur, "SELECT 1")
+            row = await adapter.fetchone(cur)
+        finally:
+            await adapter.close_cursor(cur)
+        if row is None:
+            raise AssertionError("SELECT 1 must return a row")
+        return before is not adapter.transport_token(conn), row, version
+    finally:
+        await adapter.close_connection(conn)
+
+
+async def autocommit_transitions(adapter: ParityAdapter) -> tuple[bool, bool, bool]:
+    conn = await adapter.connect()
+    try:
+        initial = adapter.autocommit_state(conn)
+        await adapter.set_autocommit(conn, True)
+        enabled = adapter.autocommit_state(conn)
+        await adapter.set_autocommit(conn, False)
+        disabled = adapter.autocommit_state(conn)
+        return initial, enabled, disabled
+    finally:
+        await adapter.close_connection(conn)
+
+
+async def insert_identity_values(adapter: ParityAdapter) -> tuple[int | None, str]:
+    table = table_name("identity")
+    conn = await adapter.connect()
+    await adapter.set_autocommit(conn, True)
+    cur = adapter.cursor(conn)
+    try:
+        await adapter.execute(cur, "DROP TABLE IF EXISTS %s" % table)
+        await adapter.execute(
+            cur,
+            "CREATE TABLE %s (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(50))" % table,
+        )
+        await adapter.execute(cur, "INSERT INTO %s (name) VALUES (?)" % table, ("alpha",))
+        return adapter.lastrowid(cur), await adapter.get_last_insert_id(conn)
+    finally:
+        try:
+            await cleanup_table(adapter, conn, table)
+        finally:
+            await adapter.close_connection(conn)
+
+
+async def executemany_batch_semantics(
+    adapter: ParityAdapter,
+) -> tuple[list[tuple[int, int]], int, Row | None]:
+    table = table_name("batch")
+    conn = await adapter.connect()
+    await adapter.set_autocommit(conn, True)
+    cur = adapter.cursor(conn)
+    try:
+        await adapter.execute(cur, "DROP TABLE IF EXISTS %s" % table)
+        await adapter.execute(cur, "CREATE TABLE %s (id INT PRIMARY KEY, name VARCHAR(30))" % table)
+        results = await adapter.executemany_batch(
+            cur,
+            [
+                "INSERT INTO %s (id, name) VALUES (1, 'first')" % table,
+                "INSERT INTO %s (id, name) VALUES (2, 'second')" % table,
+                "UPDATE %s SET name = 'updated' WHERE id = 2" % table,
+            ],
+        )
+        await adapter.execute(cur, "SELECT COUNT(*) FROM %s" % table)
+        return results, cur.rowcount, await adapter.fetchone(cur)
+    finally:
+        try:
+            await cleanup_table(adapter, conn, table)
+        finally:
+            await adapter.close_connection(conn)
+
+
+async def close_cursor_then_connection(adapter: ParityAdapter) -> tuple[bool, bool]:
+    conn = await adapter.connect()
+    cur = adapter.cursor(conn)
+    try:
+        await adapter.execute(cur, "SELECT 1")
+        await adapter.close_cursor(cur)
+        await adapter.close_connection(conn)
+        return cur._closed, not conn._connected
+    finally:
+        if conn._connected:
+            await adapter.close_connection(conn)

--- a/tests/test_parity_integration.py
+++ b/tests/test_parity_integration.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime
 import json
 import os
+from collections.abc import Callable
 from typing import cast
 
 import pytest
@@ -30,6 +31,8 @@ pytestmark = [
     pytest.mark.skipif(not can_connect(), reason="CUBRID instance not available"),
 ]
 
+approx = cast(Callable[..., object], getattr(pytest, "approx"))
+
 
 @pytest.fixture(params=ADAPTERS, ids=[adapter.kind for adapter in ADAPTERS])
 def adapter(request: pytest.FixtureRequest) -> ParityAdapter:
@@ -52,7 +55,12 @@ class TestParityBasicTypes:
     @pytest.mark.asyncio
     async def test_large_string(self, adapter: ParityAdapter) -> None:
         big = "x" * 1000
-        result = await select_round_trip(adapter, [(1, big, 3.14)], table_prefix="large")
+        result = await select_round_trip(
+            adapter,
+            [(1, big, 3.14)],
+            table_prefix="large",
+            table_definition="(id INT, name VARCHAR(4096), val DOUBLE)",
+        )
         assert result == [(1, big, 3.14)]
 
 
@@ -61,7 +69,11 @@ class TestParityExecutemany:
     async def test_batch_insert(self, adapter: ParityAdapter) -> None:
         rows = [(index, "row_%d" % index, float(index) * 1.1) for index in range(50)]
         result = await select_round_trip(adapter, rows, table_prefix="batch_insert")
-        assert result == rows
+        assert len(result) == len(rows)
+        for actual, expected in zip(result, rows, strict=True):
+            assert actual[:2] == expected[:2]
+            # DOUBLE round-trips can normalize the final binary float bits.
+            assert actual[2] == approx(expected[2], abs=1e-12)
 
 
 class TestParityTransactions:

--- a/tests/test_parity_integration.py
+++ b/tests/test_parity_integration.py
@@ -212,7 +212,7 @@ class TestParityConnectionLifecycle:
         assert await close_cursor_then_connection(adapter) == (True, True)
 
     @pytest.mark.asyncio
-    async def test_async_create_lob_is_explicitly_sync_only(self) -> None:
+    async def test_async_connection_has_no_create_lob_method(self) -> None:
         sync_conn = pycubrid.connect(**connect_kwargs())
         async_conn = await pycubrid.aio.connect(**connect_kwargs())
         try:

--- a/tests/test_parity_integration.py
+++ b/tests/test_parity_integration.py
@@ -1,446 +1,224 @@
-"""Sync/async parity integration tests for pycubrid.
-
-Runs identical scenarios through both the sync and async APIs to verify
-they produce identical results. Requires a running CUBRID instance.
-
-Set CUBRID_TEST_HOST / CUBRID_TEST_PORT env vars or use defaults.
-"""
-
 from __future__ import annotations
 
-import asyncio
+import datetime
+import json
 import os
-import uuid
+from typing import cast
 
 import pytest
 
 import pycubrid
 import pycubrid.aio
-
-TEST_HOST = os.environ.get("CUBRID_TEST_HOST", "localhost")
-TEST_PORT = int(os.environ.get("CUBRID_TEST_PORT", "33000"))
-TEST_DB = os.environ.get("CUBRID_TEST_DB", "testdb")
-TEST_USER = os.environ.get("CUBRID_TEST_USER", "dba")
-TEST_PASSWORD = os.environ.get("CUBRID_TEST_PASSWORD", "")
-
-
-def _can_connect() -> bool:
-    try:
-        conn = pycubrid.connect(
-            host=TEST_HOST,
-            port=TEST_PORT,
-            database=TEST_DB,
-            user=TEST_USER,
-            password=TEST_PASSWORD,
-        )
-        conn.close()
-        return True
-    except Exception:
-        return False
-
+from tests._parity_helpers import (
+    ADAPTERS,
+    ParityAdapter,
+    autocommit_transitions,
+    can_connect,
+    close_cursor_then_connection,
+    connect_kwargs,
+    executemany_batch_semantics,
+    fetchmany_round_trip,
+    insert_identity_values,
+    ping_after_drop,
+    reconnect_after_inactive_cas,
+    rollback_rows,
+    select_round_trip,
+)
 
 pytestmark = [
     pytest.mark.integration,
-    pytest.mark.skipif(not _can_connect(), reason="CUBRID instance not available"),
+    pytest.mark.skipif(not can_connect(), reason="CUBRID instance not available"),
 ]
 
 
-def _table_name() -> str:
-    return f"cookbook_parity_{uuid.uuid4().hex[:8]}"
-
-
-# ---------------------------------------------------------------------------
-# Sync helpers
-# ---------------------------------------------------------------------------
-
-
-def _sync_scenario(table: str, rows: list[tuple]) -> list:
-    """Insert rows and select them back via sync API."""
-    conn = pycubrid.connect(
-        host=TEST_HOST,
-        port=TEST_PORT,
-        database=TEST_DB,
-        user=TEST_USER,
-        password=TEST_PASSWORD,
-    )
-    conn.autocommit = False
-    try:
-        cur = conn.cursor()
-        cur.execute(f"DROP TABLE IF EXISTS {table}")
-        cur.execute(f"CREATE TABLE {table} (id INT, name VARCHAR(200), val DOUBLE)")
-        cur.executemany(f"INSERT INTO {table} (id, name, val) VALUES (?, ?, ?)", rows)
-        conn.commit()
-        cur.execute(f"SELECT id, name, val FROM {table} ORDER BY id")
-        result = cur.fetchall()
-        cur.execute(f"DROP TABLE IF EXISTS {table}")
-        conn.commit()
-        return result
-    finally:
-        conn.close()
-
-
-async def _async_scenario(table: str, rows: list[tuple]) -> list:
-    """Insert rows and select them back via async API."""
-    conn = await pycubrid.aio.connect(
-        host=TEST_HOST,
-        port=TEST_PORT,
-        database=TEST_DB,
-        user=TEST_USER,
-        password=TEST_PASSWORD,
-    )
-    await conn.set_autocommit(False)
-    try:
-        cur = conn.cursor()
-        await cur.execute(f"DROP TABLE IF EXISTS {table}")
-        await cur.execute(f"CREATE TABLE {table} (id INT, name VARCHAR(200), val DOUBLE)")
-        await cur.executemany(f"INSERT INTO {table} (id, name, val) VALUES (?, ?, ?)", rows)
-        await conn.commit()
-        await cur.execute(f"SELECT id, name, val FROM {table} ORDER BY id")
-        result = await cur.fetchall()
-        await cur.execute(f"DROP TABLE IF EXISTS {table}")
-        await conn.commit()
-        return result
-    finally:
-        await conn.close()
-
-
-# ---------------------------------------------------------------------------
-# Tests
-# ---------------------------------------------------------------------------
+@pytest.fixture(params=ADAPTERS, ids=[adapter.kind for adapter in ADAPTERS])
+def adapter(request: pytest.FixtureRequest) -> ParityAdapter:
+    return cast(ParityAdapter, request.param)
 
 
 class TestParityBasicTypes:
-    """Verify sync and async return identical results for basic types."""
-
-    def test_integers_and_strings(self):
-        table = _table_name()
+    @pytest.mark.asyncio
+    async def test_integers_and_strings(self, adapter: ParityAdapter) -> None:
         rows = [(1, "hello", 1.5), (2, "world", 2.5), (3, None, None)]
-        sync_result = _sync_scenario(table + "_s", rows)
-        async_result = asyncio.run(_async_scenario(table + "_a", rows))
-        assert sync_result == async_result
+        result = await select_round_trip(adapter, rows, table_prefix="basic")
+        assert result == [(1, "hello", 1.5), (2, "world", 2.5), (3, None, None)]
 
-    def test_null_handling(self):
-        table = _table_name()
+    @pytest.mark.asyncio
+    async def test_null_handling(self, adapter: ParityAdapter) -> None:
         rows = [(1, None, None), (2, "", 0.0)]
-        sync_result = _sync_scenario(table + "_s", rows)
-        async_result = asyncio.run(_async_scenario(table + "_a", rows))
-        assert sync_result == async_result
+        result = await select_round_trip(adapter, rows, table_prefix="nulls")
+        assert result == [(1, None, None), (2, "", 0.0)]
 
-    def test_large_string(self):
-        table = _table_name()
+    @pytest.mark.asyncio
+    async def test_large_string(self, adapter: ParityAdapter) -> None:
         big = "x" * 1000
-        rows = [(1, big, 3.14)]
-        sync_result = _sync_scenario(table + "_s", rows)
-        async_result = asyncio.run(_async_scenario(table + "_a", rows))
-        assert sync_result == async_result
+        result = await select_round_trip(adapter, [(1, big, 3.14)], table_prefix="large")
+        assert result == [(1, big, 3.14)]
 
 
 class TestParityExecutemany:
-    """Verify executemany produces same results via sync/async."""
-
-    def test_batch_insert(self):
-        table = _table_name()
-        rows = [(i, f"row_{i}", float(i) * 1.1) for i in range(50)]
-        sync_result = _sync_scenario(table + "_s", rows)
-        async_result = asyncio.run(_async_scenario(table + "_a", rows))
-        assert sync_result == async_result
+    @pytest.mark.asyncio
+    async def test_batch_insert(self, adapter: ParityAdapter) -> None:
+        rows = [(index, "row_%d" % index, float(index) * 1.1) for index in range(50)]
+        result = await select_round_trip(adapter, rows, table_prefix="batch_insert")
+        assert result == rows
 
 
 class TestParityTransactions:
-    """Verify transaction rollback semantics are identical."""
-
-    def test_rollback_discards_inserts(self):
-        table = _table_name()
-
-        # Sync: insert then rollback
-        conn = pycubrid.connect(
-            host=TEST_HOST,
-            port=TEST_PORT,
-            database=TEST_DB,
-            user=TEST_USER,
-            password=TEST_PASSWORD,
-        )
-        conn.autocommit = False
-        cur = conn.cursor()
-        cur.execute(f"DROP TABLE IF EXISTS {table}")
-        cur.execute(f"CREATE TABLE {table} (id INT)")
-        conn.commit()
-        cur.execute(f"INSERT INTO {table} (id) VALUES (?)", (999,))
-        conn.rollback()
-        cur.execute(f"SELECT id FROM {table}")
-        sync_result = cur.fetchall()
-        cur.execute(f"DROP TABLE {table}")
-        conn.commit()
-        conn.close()
-
-        # Async: same scenario
-        async def _async_rollback():
-            c = await pycubrid.aio.connect(
-                host=TEST_HOST,
-                port=TEST_PORT,
-                database=TEST_DB,
-                user=TEST_USER,
-                password=TEST_PASSWORD,
-            )
-            await c.set_autocommit(False)
-            cr = c.cursor()
-            await cr.execute(f"DROP TABLE IF EXISTS {table}")
-            await cr.execute(f"CREATE TABLE {table} (id INT)")
-            await c.commit()
-            await cr.execute(f"INSERT INTO {table} (id) VALUES (?)", (999,))
-            await c.rollback()
-            await cr.execute(f"SELECT id FROM {table}")
-            result = await cr.fetchall()
-            await cr.execute(f"DROP TABLE {table}")
-            await c.commit()
-            await c.close()
-            return result
-
-        async_result = asyncio.run(_async_rollback())
-        assert sync_result == async_result == []
+    @pytest.mark.asyncio
+    async def test_rollback_discards_inserts(self, adapter: ParityAdapter) -> None:
+        assert await rollback_rows(adapter) == []
 
 
 class TestParityFetchMethods:
-    """Verify fetchone/fetchmany/fetchall parity."""
-
-    def test_fetchmany_parity(self):
-        table = _table_name()
-        rows = [(i, f"item_{i}", float(i)) for i in range(10)]
-
-        # Sync
-        conn = pycubrid.connect(
-            host=TEST_HOST,
-            port=TEST_PORT,
-            database=TEST_DB,
-            user=TEST_USER,
-            password=TEST_PASSWORD,
-        )
-        conn.autocommit = True
-        cur = conn.cursor()
-        cur.execute(f"DROP TABLE IF EXISTS {table}")
-        cur.execute(f"CREATE TABLE {table} (id INT, name VARCHAR(100), val DOUBLE)")
-        cur.executemany(f"INSERT INTO {table} (id, name, val) VALUES (?, ?, ?)", rows)
-        cur.execute(f"SELECT id, name, val FROM {table} ORDER BY id")
-        sync_batch1 = cur.fetchmany(3)
-        sync_batch2 = cur.fetchmany(3)
-        sync_rest = cur.fetchall()
-        cur.execute(f"DROP TABLE {table}")
-        conn.close()
-
-        # Async
-        async def _async_fetchmany():
-            c = await pycubrid.aio.connect(
-                host=TEST_HOST,
-                port=TEST_PORT,
-                database=TEST_DB,
-                user=TEST_USER,
-                password=TEST_PASSWORD,
-            )
-            await c.set_autocommit(True)
-            cr = c.cursor()
-            await cr.execute(f"DROP TABLE IF EXISTS {table}")
-            await cr.execute(f"CREATE TABLE {table} (id INT, name VARCHAR(100), val DOUBLE)")
-            await cr.executemany(f"INSERT INTO {table} (id, name, val) VALUES (?, ?, ?)", rows)
-            await cr.execute(f"SELECT id, name, val FROM {table} ORDER BY id")
-            b1 = await cr.fetchmany(3)
-            b2 = await cr.fetchmany(3)
-            rest = await cr.fetchall()
-            await cr.execute(f"DROP TABLE {table}")
-            await c.close()
-            return b1, b2, rest
-
-        ab1, ab2, arest = asyncio.run(_async_fetchmany())
-        assert sync_batch1 == ab1
-        assert sync_batch2 == ab2
-        assert sync_rest == arest
+    @pytest.mark.asyncio
+    async def test_fetchmany_parity(self, adapter: ParityAdapter) -> None:
+        batch_one, batch_two, remaining = await fetchmany_round_trip(adapter)
+        assert batch_one == [(0, "item_0", 0.0), (1, "item_1", 1.0), (2, "item_2", 2.0)]
+        assert batch_two == [(3, "item_3", 3.0), (4, "item_4", 4.0), (5, "item_5", 5.0)]
+        assert remaining == [
+            (6, "item_6", 6.0),
+            (7, "item_7", 7.0),
+            (8, "item_8", 8.0),
+            (9, "item_9", 9.0),
+        ]
 
 
 class TestParityBytes:
-    """Verify bytes/BLOB round-trip parity."""
-
-    def test_blob_round_trip(self):
-        table = _table_name()
-        blob_data = bytes(range(256)) * 4
-
-        conn = pycubrid.connect(
-            host=TEST_HOST, port=TEST_PORT, database=TEST_DB, user=TEST_USER, password=TEST_PASSWORD
+    @pytest.mark.asyncio
+    async def test_blob_round_trip(self, adapter: ParityAdapter) -> None:
+        payload = bytes(range(256)) * 4
+        result = await select_round_trip(
+            adapter,
+            [(1, payload)],
+            table_prefix="blob",
+            table_definition="(id INT, payload BIT VARYING(8192))",
+            insert_sql="INSERT INTO {table} (id, payload) VALUES (?, ?)",
+            select_sql="SELECT payload FROM {table} WHERE id = 1",
+            autocommit=True,
         )
-        conn.autocommit = True
-        cur = conn.cursor()
-        cur.execute(f"DROP TABLE IF EXISTS {table}")
-        cur.execute(f"CREATE TABLE {table} (id INT, payload BIT VARYING(8192))")
-        cur.execute(f"INSERT INTO {table} (id, payload) VALUES (?, ?)", (1, blob_data))
-        cur.execute(f"SELECT payload FROM {table} WHERE id = 1")
-        sync_result = cur.fetchone()
-        cur.execute(f"DROP TABLE {table}")
-        conn.close()
+        assert result == [(payload,)]
 
-        async def _async_blob():
-            c = await pycubrid.aio.connect(
-                host=TEST_HOST,
-                port=TEST_PORT,
-                database=TEST_DB,
-                user=TEST_USER,
-                password=TEST_PASSWORD,
-            )
-            await c.set_autocommit(True)
-            cr = c.cursor()
-            await cr.execute(f"DROP TABLE IF EXISTS {table}")
-            await cr.execute(f"CREATE TABLE {table} (id INT, payload BIT VARYING(8192))")
-            await cr.execute(f"INSERT INTO {table} (id, payload) VALUES (?, ?)", (1, blob_data))
-            await cr.execute(f"SELECT payload FROM {table} WHERE id = 1")
-            result = await cr.fetchone()
-            await cr.execute(f"DROP TABLE {table}")
-            await c.close()
-            return result
-
-        async_result = asyncio.run(_async_blob())
-        assert sync_result == async_result
-
-
-class TestParityDatetime:
-    """Verify datetime types round-trip parity."""
-
-    def test_datetime_round_trip(self):
-        import datetime
-
-        table = _table_name()
-        dt = datetime.datetime(2025, 6, 15, 10, 30, 45)
-        d = datetime.date(2025, 6, 15)
-        t = datetime.time(10, 30, 45)
-
-        conn = pycubrid.connect(
-            host=TEST_HOST, port=TEST_PORT, database=TEST_DB, user=TEST_USER, password=TEST_PASSWORD
+    @pytest.mark.asyncio
+    async def test_datetime_round_trip(self, adapter: ParityAdapter) -> None:
+        value = datetime.datetime(2025, 6, 15, 10, 30, 45)
+        result = await select_round_trip(
+            adapter,
+            [(1, value, datetime.date(2025, 6, 15), datetime.time(10, 30, 45))],
+            table_prefix="datetime",
+            table_definition="(id INT, dt DATETIME, d DATE, t TIME)",
+            insert_sql="INSERT INTO {table} VALUES (?, ?, ?, ?)",
+            select_sql="SELECT dt, d, t FROM {table} WHERE id = 1",
+            autocommit=True,
         )
-        conn.autocommit = True
-        cur = conn.cursor()
-        cur.execute(f"DROP TABLE IF EXISTS {table}")
-        cur.execute(f"CREATE TABLE {table} (id INT, dt DATETIME, d DATE, t TIME)")
-        cur.execute(f"INSERT INTO {table} VALUES (?, ?, ?, ?)", (1, dt, d, t))
-        cur.execute(f"SELECT dt, d, t FROM {table} WHERE id = 1")
-        sync_result = cur.fetchone()
-        cur.execute(f"DROP TABLE {table}")
-        conn.close()
+        assert result == [(value, datetime.date(2025, 6, 15), datetime.time(10, 30, 45))]
 
-        async def _async_dt():
-            c = await pycubrid.aio.connect(
-                host=TEST_HOST,
-                port=TEST_PORT,
-                database=TEST_DB,
-                user=TEST_USER,
-                password=TEST_PASSWORD,
-            )
-            await c.set_autocommit(True)
-            cr = c.cursor()
-            await cr.execute(f"DROP TABLE IF EXISTS {table}")
-            await cr.execute(f"CREATE TABLE {table} (id INT, dt DATETIME, d DATE, t TIME)")
-            await cr.execute(f"INSERT INTO {table} VALUES (?, ?, ?, ?)", (1, dt, d, t))
-            await cr.execute(f"SELECT dt, d, t FROM {table} WHERE id = 1")
-            result = await cr.fetchone()
-            await cr.execute(f"DROP TABLE {table}")
-            await c.close()
-            return result
-
-        async_result = asyncio.run(_async_dt())
-        assert sync_result == async_result
-
-
-class TestParityFetchSize:
-    """Verify large fetch_size produces identical results."""
-
-    def test_large_fetch_size(self):
-        table = _table_name()
-        rows = [(i, f"row_{i}", float(i)) for i in range(200)]
-
-        conn = pycubrid.connect(
-            host=TEST_HOST,
-            port=TEST_PORT,
-            database=TEST_DB,
-            user=TEST_USER,
-            password=TEST_PASSWORD,
+    @pytest.mark.asyncio
+    async def test_large_fetch_size(self, adapter: ParityAdapter) -> None:
+        rows = [(index, "row_%d" % index, float(index)) for index in range(200)]
+        result = await select_round_trip(
+            adapter,
+            rows,
+            table_prefix="fetch_size",
+            autocommit=True,
             fetch_size=500,
         )
-        conn.autocommit = True
-        cur = conn.cursor()
-        cur.execute(f"DROP TABLE IF EXISTS {table}")
-        cur.execute(f"CREATE TABLE {table} (id INT, name VARCHAR(100), val DOUBLE)")
-        cur.executemany(f"INSERT INTO {table} (id, name, val) VALUES (?, ?, ?)", rows)
-        cur.execute(f"SELECT id, name, val FROM {table} ORDER BY id")
-        sync_result = cur.fetchall()
-        cur.execute(f"DROP TABLE {table}")
-        conn.close()
+        assert result == rows
 
-        async def _async_large_fetch():
-            c = await pycubrid.aio.connect(
-                host=TEST_HOST,
-                port=TEST_PORT,
-                database=TEST_DB,
-                user=TEST_USER,
-                password=TEST_PASSWORD,
-                fetch_size=500,
-            )
-            await c.set_autocommit(True)
-            cr = c.cursor()
-            await cr.execute(f"DROP TABLE IF EXISTS {table}")
-            await cr.execute(f"CREATE TABLE {table} (id INT, name VARCHAR(100), val DOUBLE)")
-            await cr.executemany(f"INSERT INTO {table} (id, name, val) VALUES (?, ?, ?)", rows)
-            await cr.execute(f"SELECT id, name, val FROM {table} ORDER BY id")
-            result = await cr.fetchall()
-            await cr.execute(f"DROP TABLE {table}")
-            await c.close()
-            return result
-
-        async_result = asyncio.run(_async_large_fetch())
-        assert sync_result == async_result
-        assert len(sync_result) == 200
-
-
-class TestParityJsonDeserializer:
-    """Verify JSON deserialization parity."""
-
-    def test_json_column(self):
-        import json
-
-        table = _table_name()
-        data = {"key": "value", "number": 42, "nested": [1, 2, 3]}
-
-        conn = pycubrid.connect(
-            host=TEST_HOST,
-            port=TEST_PORT,
-            database=TEST_DB,
-            user=TEST_USER,
-            password=TEST_PASSWORD,
+    @pytest.mark.asyncio
+    async def test_json_column(self, adapter: ParityAdapter) -> None:
+        payload = {"key": "value", "number": 42, "nested": [1, 2, 3]}
+        result = await select_round_trip(
+            adapter,
+            [(1, json.dumps(payload))],
+            table_prefix="json",
+            table_definition="(id INT, payload JSON)",
+            insert_sql="INSERT INTO {table} VALUES (?, ?)",
+            select_sql="SELECT payload FROM {table} WHERE id = 1",
+            autocommit=True,
             json_deserializer=json.loads,
         )
-        conn.autocommit = True
-        cur = conn.cursor()
-        cur.execute(f"DROP TABLE IF EXISTS {table}")
-        cur.execute(f"CREATE TABLE {table} (id INT, payload JSON)")
-        cur.execute(f"INSERT INTO {table} VALUES (?, ?)", (1, json.dumps(data)))
-        cur.execute(f"SELECT payload FROM {table} WHERE id = 1")
-        sync_result = cur.fetchone()
-        cur.execute(f"DROP TABLE {table}")
-        conn.close()
+        assert result == [(payload,)]
 
-        async def _async_json():
-            c = await pycubrid.aio.connect(
-                host=TEST_HOST,
-                port=TEST_PORT,
-                database=TEST_DB,
-                user=TEST_USER,
-                password=TEST_PASSWORD,
-                json_deserializer=json.loads,
-            )
-            await c.set_autocommit(True)
-            cr = c.cursor()
-            await cr.execute(f"DROP TABLE IF EXISTS {table}")
-            await cr.execute(f"CREATE TABLE {table} (id INT, payload JSON)")
-            await cr.execute(f"INSERT INTO {table} VALUES (?, ?)", (1, json.dumps(data)))
-            await cr.execute(f"SELECT payload FROM {table} WHERE id = 1")
-            result = await cr.fetchone()
-            await cr.execute(f"DROP TABLE {table}")
-            await c.close()
-            return result
 
-        async_result = asyncio.run(_async_json())
-        assert sync_result == async_result
+class TestParityConnectionLifecycle:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("reconnect", [False, True], ids=["no-reconnect", "reconnect"])
+    async def test_ping_healthy_connection(
+        self,
+        adapter: ParityAdapter,
+        reconnect: bool,
+    ) -> None:
+        conn = await adapter.connect()
+        try:
+            assert await adapter.ping(conn, reconnect=reconnect) is True
+        finally:
+            await adapter.close_connection(conn)
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        not os.getenv("CUBRID_TEST_URL"),
+        reason="Set CUBRID_TEST_URL to run broker drop parity scenarios",
+    )
+    @pytest.mark.parametrize("reconnect", [False, True], ids=["no-reconnect", "reconnect"])
+    async def test_ping_after_transport_drop(
+        self,
+        adapter: ParityAdapter,
+        reconnect: bool,
+    ) -> None:
+        ping_result, row = await ping_after_drop(adapter, reconnect=reconnect)
+        assert ping_result is reconnect
+        expected_row = (1,) if reconnect else None
+        assert row == expected_row
+
+    @pytest.mark.asyncio
+    async def test_reconnect_after_inactive_cas(self, adapter: ParityAdapter) -> None:
+        reconnected, row, version = await reconnect_after_inactive_cas(adapter)
+        assert reconnected is True
+        assert row == (1,)
+        assert version
+
+    @pytest.mark.asyncio
+    async def test_autocommit_transitions(self, adapter: ParityAdapter) -> None:
+        assert await autocommit_transitions(adapter) == (False, True, False)
+
+    @pytest.mark.asyncio
+    async def test_lastrowid_and_last_insert_id(self, adapter: ParityAdapter) -> None:
+        lastrowid, last_insert_id = await insert_identity_values(adapter)
+        assert isinstance(lastrowid, int)
+        assert lastrowid is not None and lastrowid > 0
+        assert last_insert_id == str(lastrowid)
+
+    @pytest.mark.asyncio
+    async def test_get_server_version(self, adapter: ParityAdapter) -> None:
+        conn = await adapter.connect()
+        try:
+            version = await adapter.get_server_version(conn)
+        finally:
+            await adapter.close_connection(conn)
+        assert isinstance(version, str)
+        assert version
+        assert version.split(".", 1)[0].isdigit()
+
+    @pytest.mark.asyncio
+    async def test_executemany_batch_rowcount_semantics(self, adapter: ParityAdapter) -> None:
+        results, rowcount, count_row = await executemany_batch_semantics(adapter)
+        assert len(results) == 3
+        assert rowcount == sum(count for _, count in results)
+        assert count_row == (2,)
+
+    @pytest.mark.asyncio
+    async def test_cursor_close_then_connection_close(self, adapter: ParityAdapter) -> None:
+        assert await close_cursor_then_connection(adapter) == (True, True)
+
+    @pytest.mark.asyncio
+    async def test_async_create_lob_is_explicitly_sync_only(self) -> None:
+        sync_conn = pycubrid.connect(**connect_kwargs())
+        async_conn = await pycubrid.aio.connect(**connect_kwargs())
+        try:
+            assert callable(sync_conn.create_lob)
+            with pytest.raises(AttributeError, match="create_lob"):
+                getattr(async_conn, "create_lob")()
+        finally:
+            sync_conn.close()
+            await async_conn.close()


### PR DESCRIPTION
Closes #140.

## Summary
- refactor sync/async parity integration tests around shared async-first driver adapters in `tests/_parity_helpers.py`
- add lifecycle parity scenarios for ping, CAS-inactive reconnect, autocommit transitions, insert identity helpers, batch rowcount semantics, and close ordering
- document the current `AsyncConnection` `create_lob` `AttributeError` contract and record the expanded coverage in the changelog

## Test Plan
- make lint
- make test
- python3 -m pytest tests/test_parity_integration.py -q --ignore=tests/test_integration.py

## Notes
- broker-drop parity scenarios remain env-gated behind `CUBRID_TEST_URL`
- integration parity scenarios are still collected from `tests/test_parity_integration.py` and will run in the existing CI integration matrix

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)
Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>