### PR TITLE
test: add concurrent connect/ping(reconnect=True) coverage for AsyncConnection

### DIFF
--- a/tests/test_aio_concurrency.py
+++ b/tests/test_aio_concurrency.py
@@ -120,3 +120,143 @@ async def test_close_waits_for_in_flight_send_and_receive() -> None:
     assert events == ["request-start", "request-finish", "close"]
     assert conn._connected is False
     assert conn._writer is None
+
+
+@pytest.mark.asyncio
+async def test_concurrent_connect_performs_single_handshake() -> None:
+    conn = AsyncConnection("localhost", 33000, "testdb", "dba", "")
+
+    handshake_calls = 0
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def fake_open_connection(host: str, port: int) -> tuple[MagicMock, MagicMock]:
+        reader = MagicMock()
+        writer = MagicMock()
+        writer.close = MagicMock()
+        writer.wait_closed = AsyncMock()
+        return reader, writer
+
+    async def fake_do_connect_handshake(hs_reader: Any, hs_writer: Any) -> None:
+        nonlocal handshake_calls
+        handshake_calls += 1
+        # Block the first handshake until we've queued all concurrent callers,
+        # forcing them to contend on the connect path.
+        started.set()
+        await release.wait()
+        conn._reader = hs_reader
+        conn._writer = hs_writer
+        conn._cas_info = b"\x01\x00\x00\x00"
+        conn._session_id = 1
+
+    conn._open_connection = AsyncMock(side_effect=fake_open_connection)
+    conn._do_connect_handshake = AsyncMock(side_effect=fake_do_connect_handshake)
+
+    n = 5
+    first = asyncio.create_task(conn.connect())
+    await started.wait()
+    others = [asyncio.create_task(conn.connect()) for _ in range(n - 1)]
+    await asyncio.sleep(0)
+    for task in others:
+        assert not task.done(), "concurrent connect() should wait on the lock"
+
+    release.set()
+    await asyncio.gather(first, *others)
+
+    assert handshake_calls == 1, (
+        f"expected single handshake under concurrency, got {handshake_calls}"
+    )
+    assert conn._connected is True
+
+
+@pytest.mark.asyncio
+async def test_concurrent_ping_reconnect_performs_single_reconnect() -> None:
+    conn = make_connected_async_connection()
+    conn._cas_info = bytes([AsyncConnection._CAS_INFO_STATUS_INACTIVE, 0x00, 0x00, 0x00])
+
+    handshake_calls = 0
+
+    async def fake_open_connection(host: str, port: int) -> tuple[Any, Any]:
+        reader = MagicMock()
+        writer = MagicMock()
+        writer.close = MagicMock()
+        writer.wait_closed = AsyncMock()
+        return reader, writer
+
+    async def fake_do_connect_handshake(hs_reader: Any, hs_writer: Any) -> None:
+        nonlocal handshake_calls
+        handshake_calls += 1
+        conn._reader = hs_reader
+        conn._writer = hs_writer
+        conn._cas_info = bytes([AsyncConnection._CAS_INFO_STATUS_ACTIVE, 0x00, 0x00, 0x00])
+        conn._session_id = 1
+
+    async def fake_do_send_and_receive(packet: Any) -> Any:
+        packet.response_code = 0
+        return packet
+
+    conn._open_connection = AsyncMock(side_effect=fake_open_connection)
+    conn._do_connect_handshake = AsyncMock(side_effect=fake_do_connect_handshake)
+    conn._do_send_and_receive = AsyncMock(side_effect=fake_do_send_and_receive)
+
+    n = 5
+    results = await asyncio.gather(*[conn.ping(reconnect=True) for _ in range(n)])
+
+    assert all(results)
+    assert handshake_calls == 1
+    assert conn._connected is True
+
+
+@pytest.mark.asyncio
+async def test_concurrent_ping_reconnect_with_subclass_connect_no_deadlock() -> None:
+    class _TracingAsyncConnection(AsyncConnection):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            super().__init__(*args, **kwargs)
+            self.subclass_connect_calls = 0
+
+        async def connect(self) -> None:
+            self.subclass_connect_calls += 1
+            if self._connected:
+                return
+            await self._connect_locked()
+
+    conn = _TracingAsyncConnection("localhost", 33000, "testdb", "dba", "")
+    conn._connected = True
+    conn._cas_info = bytes([AsyncConnection._CAS_INFO_STATUS_INACTIVE, 0x00, 0x00, 0x00])
+    conn._reader = MagicMock()
+    conn._writer = MagicMock()
+    conn._writer.close = MagicMock()
+    conn._writer.wait_closed = AsyncMock()
+
+    async def fake_open_connection(host: str, port: int) -> tuple[Any, Any]:
+        reader = MagicMock()
+        writer = MagicMock()
+        writer.close = MagicMock()
+        writer.wait_closed = AsyncMock()
+        return reader, writer
+
+    async def fake_do_connect_handshake(hs_reader: Any, hs_writer: Any) -> None:
+        conn._reader = hs_reader
+        conn._writer = hs_writer
+        conn._cas_info = bytes([AsyncConnection._CAS_INFO_STATUS_ACTIVE, 0x00, 0x00, 0x00])
+        conn._session_id = 1
+
+    async def fake_do_send_and_receive(packet: Any) -> Any:
+        packet.response_code = 0
+        return packet
+
+    conn._open_connection = AsyncMock(side_effect=fake_open_connection)
+    conn._do_connect_handshake = AsyncMock(side_effect=fake_do_connect_handshake)
+    conn._do_send_and_receive = AsyncMock(side_effect=fake_do_send_and_receive)
+
+    n = 3
+    try:
+        results = await asyncio.wait_for(
+            asyncio.gather(*[conn.ping(reconnect=True) for _ in range(n)]),
+            timeout=2.0,
+        )
+    except asyncio.TimeoutError:
+        pytest.fail("ping(reconnect=True) with subclass connect() override deadlocked")
+
+    assert all(results)
+    assert conn.subclass_connect_calls >= 1


### PR DESCRIPTION
## Summary

Closes #148.

Adds three new tests to `tests/test_aio_concurrency.py` exercising the connect/reconnect entry paths under concurrency, complementing PR #141's existing coverage of `_send_and_receive`.

## Tests added

1. **`test_concurrent_connect_performs_single_handshake`** — N concurrent `conn.connect()` calls on the same instance produce exactly **one** `_do_connect_handshake` invocation (per-connection `asyncio.Lock` + `_connect_locked` early-return on `_connected`). No deadlock; all N tasks return.

2. **`test_concurrent_ping_reconnect_performs_single_reconnect`** — N concurrent `conn.ping(reconnect=True)` calls observing CAS-inactive trigger exactly **one** reconnect handshake. `_check_reconnect_locked` refreshes `_cas_info` to ACTIVE on first reconnect; second-and-later pings observe ACTIVE and skip reconnect. All N report healthy.

3. **`test_concurrent_ping_reconnect_with_subclass_connect_no_deadlock`** (optional per issue) — A subclass overriding `connect()` and delegating via `_connect_locked()` (the contract honored by `_invoke_connect_locked` when the lock is already held) completes under concurrent `ping(reconnect=True)` within a 2 s timeout, ruling out lock-recursion deadlock.

## Mocking strategy

Tests count actual handshakes via `_do_connect_handshake` instead of `_connect_locked` so the real `if self._connected: return` early-return is exercised. This accurately reflects the design's single-handshake guarantee under race rather than counting every (cheap) lock-acquire-then-early-return entry.

## Verification

- `pytest tests/test_aio_concurrency.py` → **5 passed**
- `pytest tests/` (full offline) → **836 passed, 53 skipped**
- `ruff check` + `ruff format --check` → clean

## Acceptance criteria

- [x] Test: N concurrent `conn.connect()` calls on the same instance result in exactly one handshake and N successful returns
- [x] Test: N concurrent `conn.ping(reconnect=True)` calls after CAS-inactive simulation produce at most one reconnect attempt and all callers observe a healthy connection
- [x] (Optional) Test: subclass override of `connect()` does not deadlock under the same patterns