### PR TITLE
docs: align TLS/handshake docs with merged STARTTLS implementation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,13 +67,14 @@ graph TD
 
 ### Handshake Flow
 
-1. **ClientInfoExchange**: Send `"CUBRK"` + client type + version (10 bytes, NO header)
-2. **OpenDatabase**: Send db/user/password (628 bytes payload with header)
-3. **PrepareAndExecute / Prepare+Execute → Fetch → CloseQuery → EndTran → CloseDatabase**
+1. **ClientInfoExchange**: Send 10 bytes (NO header) — magic `"CUBRS"` when `ssl` is requested (STARTTLS) or `"CUBRK"` plaintext, plus client type + version. Broker replies a 4-byte int32: `0`=ok, `<0`=fail-fast (`OperationalError`), `>0`=redirect port (reconnect on the new port WITHOUT repeating the handshake).
+2. **TLS upgrade (optional)**: If `ssl` was truthy, upgrade the live transport via `loop.start_tls()` (async) or `ssl.SSLContext.wrap_socket()` (sync) before `OPEN_DATABASE`.
+3. **OpenDatabase**: Send db/user/password (628 bytes payload with header)
+4. **PrepareAndExecute / Prepare+Execute → Fetch → CloseQuery → EndTran → CloseDatabase**
 
 ### Key Constants
 
-- Magic string: `"CUBRK"`
+- Magic string: `"CUBRK"` (plaintext) or `"CUBRS"` (STARTTLS-requested)
 - Client type: `CAS_CLIENT_JDBC = 3`
 - Protocol version: `7` (since CUBRID 10.0.0)
 - Byte order: Big-endian throughout

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,6 +45,6 @@ Python 3.10+, CUBRID 10.2–11.4
 
 ### TLS & Transport (v1.3.0 / v1.4.0)
 - Sync TLS via `ssl=True` or custom `ssl.SSLContext` (v1.3.0)
-- Async TLS via `pycubrid.aio.connect(ssl=...)` using `asyncio.open_connection(ssl=...)` (v1.4.0)
+- Async TLS via `pycubrid.aio.connect(ssl=...)` using CUBRID's STARTTLS-style upgrade (plaintext `CUBRS` handshake → `loop.start_tls()`; v1.4.0, corrected in #154)
 - Default TLS context enforces TLS 1.2 minimum (v1.4.0)
 - Expanded Python 3.14 / CUBRID 10.2–11.4 CI coverage

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -102,7 +102,7 @@ Create a new database connection.
 | `password` | `str` | `""` | Database password |
 | `decode_collections` | `bool` | `False` | Decode SET/MULTISET/SEQUENCE columns into Python collections |
 | `json_deserializer` | `Any` | `None` | Callable used to decode JSON columns on fetch; when unset JSON is returned as `str` |
-| `ssl` | `bool \| ssl_module.SSLContext \| None` | `None` | Opt-in TLS for sync and async broker connections; `True` uses the default verified context with a TLS 1.2 minimum |
+| `ssl` | `bool \| ssl_module.SSLContext \| None` | `None` | Opt-in TLS for sync and async broker connections; `True` uses the default verified context with a TLS 1.2 minimum. Connection uses CUBRID's STARTTLS-style upgrade — plaintext `CUBRS` handshake then TLS upgrade before `OPEN_DATABASE`. See [Connection guide](CONNECTION.md#ssltls). |
 | `**kwargs` | `Any` | — | Additional parameters such as `connect_timeout`, `read_timeout`, `fetch_size`, `enable_timing`, `no_backslash_escapes`, and `autocommit` |
 
 #### `decode_collections`
@@ -167,7 +167,7 @@ Create and open an async connection.
 - Accepts the same collection / JSON decoding kwargs as `pycubrid.connect()`.
 - Supports `autocommit=True` via `await conn.set_autocommit(True)` during construction.
 - Provides a similar async surface to the sync API, including `await conn.ping(reconnect=...)`; `create_lob()` remains sync-only, and auto-commit changes go through `await conn.set_autocommit(...)` instead of a property setter.
-- Accepts the same `ssl` parameter as `pycubrid.connect()`: `True`, `False`/`None`, or a custom `SSLContext`; when `True`, the default verified context enforces a TLS 1.2 minimum.
+- Accepts the same `ssl` parameter as `pycubrid.connect()`: `True`, `False`/`None`, or a custom `SSLContext`; when `True`, the default verified context enforces a TLS 1.2 minimum. Async TLS uses CUBRID's STARTTLS-style upgrade — the `CUBRS` handshake is sent in plaintext, then the transport is upgraded via `asyncio.AbstractEventLoop.start_tls()` (bounded by `ssl_handshake_timeout`) before `OPEN_DATABASE`. See the [Connection guide](CONNECTION.md#ssltls) for full details and the Python 3.10 `start_tls()` cert-verify caveat ([#156](https://github.com/cubrid-lab/pycubrid/issues/156)).
 
 ```python
 import asyncio

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -24,9 +24,18 @@ sequenceDiagram
     rect rgb(230, 245, 255)
       note over pycubrid, CAS: Phase 1 — Broker Handshake
       pycubrid->>Broker: TCP connect to port 33000
-      pycubrid->>Broker: ClientInfoExchange ("CUBRK" + CLIENT_JDBC=3 + v8)
-      Broker-->>pycubrid: New CAS port (4B int32)
-      pycubrid->>CAS: TCP reconnect to CAS port
+      alt ssl truthy
+        pycubrid->>Broker: ClientInfoExchange ("CUBRS" + CLIENT_JDBC=3 + v8)
+      else plaintext
+        pycubrid->>Broker: ClientInfoExchange ("CUBRK" + CLIENT_JDBC=3 + v8)
+      end
+      Broker-->>pycubrid: status int32 (0 ok / >0 redirect port / <0 fail-fast)
+      opt status > 0 (redirect)
+        pycubrid->>CAS: TCP reconnect to redirected port (no rehandshake)
+      end
+      opt ssl truthy
+        pycubrid->>CAS: TLS upgrade (start_tls / wrap_socket)
+      end
     end
     rect rgb(230, 255, 230)
       note over pycubrid, DB: Phase 2 — Database Session

--- a/docs/CONNECTION.md
+++ b/docs/CONNECTION.md
@@ -186,8 +186,19 @@ Both `pycubrid.connect()` and `pycubrid.aio.connect()` accept the same `ssl` val
 - `ssl=False` or `ssl=None` for plaintext.
 - `ssl=your_ssl_context` for a custom `ssl.SSLContext`.
 
-Async TLS uses `asyncio.open_connection(..., ssl=...)` internally, and async shutdown awaits
-`writer.wait_closed()` so TLS sessions close cleanly.
+Async TLS uses CUBRID's STARTTLS-style upgrade: the connection opens in plaintext, sends the
+`CUBRS` handshake magic to negotiate TLS with the broker, then upgrades the live transport via
+`asyncio.AbstractEventLoop.start_tls()` (bounded by `ssl_handshake_timeout`) **before** the
+`OPEN_DATABASE` exchange. Async shutdown awaits `writer.wait_closed()` so TLS sessions close
+cleanly. The sync driver performs the equivalent flow with `ssl.SSLContext.wrap_socket()`.
+
+!!! warning "Python 3.10 async TLS limitation"
+    On Python 3.10, `asyncio.loop.start_tls()` may hang indefinitely when a TLS handshake fails
+    due to **certificate verification** errors (CPython
+    [gh-142352](https://github.com/python/cpython/issues/142352), fixed in 3.13/3.14). Other TLS
+    error paths — peer unresponsive, timeout — remain bounded by `ssl_handshake_timeout`. The
+    issue does not affect the sync driver. Tracked in
+    [pycubrid#156](https://github.com/cubrid-lab/pycubrid/issues/156).
 
 ```python
 import pycubrid.aio
@@ -359,9 +370,18 @@ sequenceDiagram
   participant CAS
 
   Client->>Broker: TCP connect
-  Client->>Broker: ClientInfoExchangePacket (CUBRK)
-  Broker-->>Client: New CAS port
-  Client->>CAS: Reconnect to CAS port
+  alt ssl requested
+    Client->>Broker: ClientInfoExchangePacket (CUBRS)
+  else plaintext
+    Client->>Broker: ClientInfoExchangePacket (CUBRK)
+  end
+  Broker-->>Client: status int32 (0 ok / >0 redirect / <0 error)
+  opt redirected (status > 0)
+    Client->>CAS: Reconnect to new port (no second handshake)
+  end
+  opt ssl requested
+    Client->>CAS: TLS upgrade (start_tls / wrap_socket)
+  end
   Client->>CAS: OpenDatabasePacket
   CAS-->>Client: Session ID
 ```
@@ -374,14 +394,23 @@ sequenceDiagram
   participant Broker as Broker:33000
   participant CAS as CAS Worker
 
-  App->>Driver: pycubrid.connect(...)
+  App->>Driver: pycubrid.connect(..., ssl=...)
   Driver->>Broker: TCP connect
-  Driver->>Broker: ClientInfoExchangePacket("CUBRK")
-  Broker-->>Driver: new_connection_port
-  alt redirected (port > 0)
-    Driver->>CAS: TCP reconnect to redirected port
-  else direct mode (port == 0)
+  alt ssl truthy
+    Driver->>Broker: ClientInfoExchangePacket("CUBRS")
+  else ssl falsy
+    Driver->>Broker: ClientInfoExchangePacket("CUBRK")
+  end
+  Broker-->>Driver: status int32
+  alt status < 0
+    Driver-->>App: OperationalError (fail-fast)
+  else status > 0 (redirected)
+    Driver->>CAS: TCP reconnect to redirected port (skip rehandshake)
+  else status == 0 (direct mode)
     Driver->>Broker: reuse existing socket
+  end
+  opt ssl truthy
+    Driver->>CAS: TLS upgrade via start_tls() / wrap_socket()
   end
   Driver->>CAS: OpenDatabasePacket(database, user, password)
   CAS-->>Driver: session_id + broker_info + cas_info
@@ -393,13 +422,21 @@ sequenceDiagram
 
 ### Step-by-Step
 
-1. **TCP Connect** — Open a socket to the broker (default port 33000)
-2. **Client Info Exchange** — Send the magic string `b"CUBRK"` with client type `CLIENT_JDBC=3` and protocol version bytes
-3. **Port Redirect** — The broker responds with a 4-byte big-endian integer:
-   - If `port > 0`: Disconnect from broker, reconnect to the new CAS port on the same host
-   - If `port == 0`: Reuse the existing connection (direct CAS mode)
-4. **Open Database** — Send database name, username, and password via `OpenDatabasePacket`
-5. **Session Established** — Server returns a session ID; the connection is ready
+1. **TCP Connect** — Open a socket to the broker (default port 33000).
+2. **Client Info Exchange** — Send a 10-byte handshake: magic string `b"CUBRS"` when `ssl` is
+   requested (STARTTLS) or `b"CUBRK"` for plaintext, plus client type `CLIENT_JDBC=3` and
+   protocol-version bytes.
+3. **Broker Status** — The broker responds with a 4-byte big-endian signed integer:
+    - `status < 0` — fail-fast: driver raises `OperationalError`
+    - `status > 0` — redirect: close socket, reconnect to the new CAS port on the same host,
+      **without** repeating the handshake (mirrors the official JDBC `BrokerHandler` behavior)
+    - `status == 0` — direct mode: reuse the existing socket
+4. **TLS Upgrade (optional)** — If `ssl` was truthy, upgrade the live transport to TLS *before*
+   any `OPEN_DATABASE` bytes are written. Async uses
+   `asyncio.AbstractEventLoop.start_tls(..., ssl_handshake_timeout=...)`; sync uses
+   `ssl.SSLContext.wrap_socket()`. Failed handshakes abort the transport rather than leaking it.
+5. **Open Database** — Send database name, username, and password via `OpenDatabasePacket`.
+6. **Session Established** — Server returns a session ID; the connection is ready.
 
 ---
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -194,12 +194,22 @@ You do not need to run the steps above locally for routine development —
 
 1. Starts a CUBRID 11.4 container manually (so the broker config can be
    patched after the container is up).
-2. Flips `SSL=OFF` → `SSL=ON` for `BROKER1` and restarts the broker.
-3. Copies the default self-signed broker certificate out of the container.
+2. Generates a fresh self-signed certificate (`CN=localhost`, `SAN=DNS:localhost`),
+   injects it into the container as `cas_ssl_cert.{crt,key}`, then flips
+   `SSL=OFF` → `SSL=ON` for `BROKER1` and restarts the broker so the new
+   cert is picked up.
+3. Exports the generated CA bundle to the Python test fixture via
+   `CUBRID_TLS_TEST_CA_FILE` and `SSL_CERT_FILE`.
 4. Probes the broker with a real TLS handshake and fails the job loudly
    if TLS is not actually serving — silent skips are explicitly rejected.
 5. Runs `tests/test_aio_ssl_integration.py` against the TLS broker with
    the `CUBRID_TLS_TEST_*` env vars wired up automatically.
+
+> **Python 3.10 note**: One async TLS test (`test_aio_ssl_handshake_failure`)
+> is version-pinned to skip on Python 3.10 due to a CPython
+> [gh-142352](https://github.com/python/cpython/issues/142352) hang in
+> `asyncio.loop.start_tls()` on cert-verify failure (fixed in 3.13/3.14).
+> Tracked in [#156](https://github.com/cubrid-lab/pycubrid/issues/156).
 
 This job runs on the same triggers as the rest of `integration-full`
 (nightly, on tag push, and via `workflow_dispatch`).

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -204,7 +204,7 @@ Limitations imposed by CUBRID or design choices:
 
 | Feature | Status | Reason |
 |---|---|---|
-| Async TLS | ✅ | Implemented in v1.4.0; uses `asyncio.open_connection(ssl=...)`. Default context requires TLS 1.2 minimum. |
+| Async TLS | ✅ | Implemented in v1.4.0; uses CUBRID's STARTTLS-style upgrade — plaintext `CUBRS` handshake then `loop.start_tls()` (with `ssl_handshake_timeout`) before `OPEN_DATABASE` (#154). Default context requires TLS 1.2 minimum. Python 3.10 has a known `start_tls()` hang on cert-verify failures (#156). |
 | Connection pooling | ❌ | Not in scope; use SQLAlchemy's pool or external pooler |
 | Thread safety level 2+ | ❌ | CUBRID CAS sessions are connection-bound |
 | LOB streaming | ⚠️ | LOB data loaded fully into memory |

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -48,7 +48,9 @@ Key characteristics:
 - **Transport**: TCP (default port 33000 for the broker)
 - **Byte order**: Big-endian (network byte order)
 - **Framing**: 4-byte data length + 4-byte CAS info + payload
-- **Handshake**: Magic string `CUBRK` + client type + protocol version
+- **Handshake**: Magic string `CUBRK` (plaintext) or `CUBRS` (STARTTLS) + client type + protocol version
+- **TLS (optional)**: STARTTLS-style upgrade after the handshake using `start_tls()` /
+  `wrap_socket()` before `OPEN_DATABASE`
 - **Session**: Stateful — session ID maintained after `OpenDatabase`
 
 ---
@@ -104,7 +106,7 @@ The **open database packet** (`OpenDatabasePacket`) sends raw bytes (628 bytes) 
 
 ## Connection Handshake
 
-The connection flow has three phases:
+The connection flow has up to four phases (the TLS phase is optional):
 
 ### Phase 1: Client Info Exchange
 
@@ -112,14 +114,33 @@ The connection flow has three phases:
 sequenceDiagram
     participant Client
     participant Broker
-    Client->>Broker: ClientInfoExchange raw 10B ("CUBRK", CLIENT_JDBC=3, CAS_VER=0x48, padding)
-    Broker-->>Client: New Connection Port (4B int32, big-endian)
+    alt ssl requested
+        Client->>Broker: ClientInfoExchange raw 10B ("CUBRS", CLIENT_JDBC=3, CAS_VER=0x48, padding)
+    else plaintext
+        Client->>Broker: ClientInfoExchange raw 10B ("CUBRK", CLIENT_JDBC=3, CAS_VER=0x48, padding)
+    end
+    Broker-->>Client: status int32 (0 ok / >0 redirect port / <0 fail-fast)
 ```
 
-- **Magic string**: `"CUBRK"` (5 ASCII bytes)
+- **Magic string**: `"CUBRK"` (plaintext) or `"CUBRS"` (STARTTLS-requested) — 5 ASCII bytes
 - **Client type**: `CLIENT_JDBC = 3` (pycubrid identifies as a JDBC-compatible client)
 - **CAS version**: `PROTO_INDICATOR(0x40) | VERSION(8) = 0x48`
-- **New port**: If > 0, disconnect from broker and reconnect to this port. If 0, reuse current socket.
+- **Status int32**: signed big-endian
+    - `> 0` — redirect port: close socket, reconnect to `(host, status)`, **do not** repeat the
+      handshake (mirrors the JDBC `BrokerHandler.connectBroker` behavior)
+    - `< 0` — fail-fast: raise `OperationalError(status)`
+    - `== 0` — reuse the current socket (direct mode)
+
+### Phase 1.5: TLS Upgrade (optional)
+
+If `ssl` was truthy on the connect call, the live transport is upgraded **before** any
+`OPEN_DATABASE` bytes are written:
+
+- Sync driver: `ssl.SSLContext.wrap_socket(sock, server_hostname=host)`
+- Async driver: `loop.start_tls(transport, protocol, context, server_hostname=host,
+  ssl_handshake_timeout=...)`
+
+A failed handshake aborts the transport rather than leaking it.
 
 ### Phase 2: Open Database
 
@@ -579,11 +600,12 @@ pycubrid classifies errors automatically:
 
 ```python
 class CASProtocol:
-    MAGIC_STRING = "CUBRK"    # Handshake magic
-    CLIENT_JDBC = 3           # Client type identifier
-    PROTO_INDICATOR = 0x40    # Protocol indicator bit
-    VERSION = 8               # Protocol version
-    CAS_VERSION = 0x48        # Combined version byte
+    MAGIC_STRING = "CUBRK"      # Handshake magic (plaintext)
+    MAGIC_STRING_TLS = "CUBRS"  # Handshake magic (STARTTLS-requested)
+    CLIENT_JDBC = 3             # Client type identifier
+    PROTO_INDICATOR = 0x40      # Protocol indicator bit
+    VERSION = 8                 # Protocol version
+    CAS_VERSION = 0x48          # Combined version byte
 ```
 
 ### Wire Data Sizes

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -83,7 +83,7 @@ The 5 × 4 full integration matrix is run by `.github/workflows/integration-full
 | Sync TLS — `ssl=True` (verified context) | ✅ | 1.3.0 (#85) | Default secure context |
 | Sync TLS — `ssl=ssl.SSLContext(...)` | ✅ | 1.3.0 (#85) | Custom context |
 | Sync TLS — `ssl=False` / `None` | ✅ | 1.3.0 | Plaintext (default) |
-| Async TLS | ✅ | 1.4.0 | Uses `asyncio.open_connection(ssl=...)` (#136); default context enforces TLS 1.2 minimum (#145). |
+| Async TLS | ✅ | 1.4.0 | STARTTLS-style upgrade: plaintext `CUBRS` handshake then `loop.start_tls()` (`ssl_handshake_timeout` bounded) before `OPEN_DATABASE` (#136, #154). Default context enforces TLS 1.2 minimum (#145). Python 3.10 has a known `start_tls()` hang on cert-verify failures (CPython gh-142352) — tracked as #156. |
 
 ### Async (`pycubrid.aio`)
 
@@ -96,7 +96,7 @@ The 5 × 4 full integration matrix is run by `.github/workflows/integration-full
 | Async `read_timeout` | ✅ | 1.2.0 (#82) | |
 | Async dual-stack fallback | ✅ | 1.2.0 (#83) | |
 | Async parameter binding parity | ✅ | 1.2.0 (#76, #77) | Shares `_escape_string` with sync |
-| Async TLS | ✅ | 1.4.0 | Uses `asyncio.open_connection(ssl=...)` (#136); default context enforces TLS 1.2 minimum (#145). |
+| Async TLS | ✅ | 1.4.0 | STARTTLS-style upgrade: plaintext `CUBRS` handshake then `loop.start_tls()` (`ssl_handshake_timeout` bounded) before `OPEN_DATABASE` (#136, #154). Default context enforces TLS 1.2 minimum (#145). Python 3.10 has a known `start_tls()` hang on cert-verify failures (CPython gh-142352) — tracked as #156. |
 
 ### Driver-Level Diagnostics
 


### PR DESCRIPTION
## Summary

Phase 3 (Documentation Update) follow-up to PRs #154 and #155, per
[Oracle post-implementation review](https://github.com/cubrid-lab/pycubrid/pull/155#issuecomment-) finding **documentation drift = BLOCKER**.

All affected docs now describe the merged STARTTLS-style handshake
(plaintext TCP → `CUBRS`/`CUBRK` magic → 4-byte int32 status with
redirect-no-rehandshake → optional TLS upgrade via `loop.start_tls()` /
`wrap_socket()` → `OPEN_DATABASE`), the corrected CI cert provisioning
(self-signed `CN=localhost`/`SAN=DNS:localhost`, injected into the
container), and the Python 3.10 `start_tls()` cert-verify hang caveat
(CPython gh-142352, tracked in #156).

## Files Updated

- `docs/CONNECTION.md` — async TLS description + both Broker Handshake
  Mermaid diagrams + step-by-step; new Python 3.10 limitation callout
- `docs/PROTOCOL.md` — Overview, Phase 1 diagram/bullets, new
  Phase 1.5 (TLS Upgrade), `CASProtocol` constants block now includes
  `MAGIC_STRING_TLS = \"CUBRS\"`
- `docs/ARCHITECTURE.md` — Phase 1 sequence diagram TLS branch
- `docs/SUPPORT_MATRIX.md`, `docs/PRD.md`, `ROADMAP.md` — replaced stale
  `asyncio.open_connection(ssl=...)` claims with STARTTLS upgrade
- `docs/DEVELOPMENT.md` — corrected CI TLS coverage description
  (generates+injects cert vs. copies broker default) + 3.10 skip note
- `docs/API_REFERENCE.md` — `ssl` parameter docs (sync + async) with
  STARTTLS summary and 3.10 caveat link
- `AGENTS.md` — Handshake Flow section + Key Constants

## Consistency Audit

Audited in parallel:
- All pycubrid docs (`docs/*.md`, root `*.md`)
- 5 translated READMEs (`docs/README.{ko,zh,hi,de,ru}.md`) — no stale
  claims; their TLS bullets are generic and remain accurate (detail
  intentionally lives in `CONNECTION.md`)
- Downstream `sqlalchemy-cubrid` repo — no TLS/handshake drift; dialect
  forwards kwargs to pycubrid without re-implementing TLS

## Verification

- \`make lint\` — All checks passed
- \`make test\` — 843 passed, 58 skipped, coverage **95.55%**

## Related

- Phase 3 fix for: #154 (STARTTLS handshake), #155 (CI SSL=ON
  provisioning), #147 (closed by #155)
- Documents existing limitation: #156 (Python 3.10 \`start_tls()\` hang)
- Separate follow-up issues filed: #157 (test hardening), #158 (CI
  probe cert verification), #159 (per-PR TLS lane + nodeid grep)

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)