### PR TITLE
fix: tear down sync connection on malformed broker response (#187)

### DIFF
--- a/pycubrid/connection.py
+++ b/pycubrid/connection.py
@@ -477,7 +477,12 @@ class Connection(ConnectionCommonMixin):
             # Update CAS_INFO from the response (first 4 bytes).
             self._cas_info = response_body[: DataSize.CAS_INFO]
 
-            packet.parse(response_body)
+            try:
+                packet.parse(response_body)
+            except (ValueError, struct.error, IndexError, UnicodeDecodeError) as exc:
+                self._safe_close_socket()
+                self._connected = False
+                raise OperationalError("malformed response from broker") from exc
             if _LOGGER.isEnabledFor(logging.DEBUG):
                 _LOGGER.debug("recv: %d bytes", data_length + DataSize.CAS_INFO)
             return packet

--- a/tests/test_network_edge_cases.py
+++ b/tests/test_network_edge_cases.py
@@ -143,6 +143,54 @@ class TestConnectionNetworkEdgeCases:
         assert packet is not None
         assert partial_sock.recv_into.call_count == 4
 
+    @pytest.mark.parametrize(
+        "parse_error",
+        [
+            ValueError("bad frame"),
+            struct.error("unpack requires more bytes"),
+            IndexError("truncated body"),
+            UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte"),
+        ],
+        ids=["ValueError", "struct.error", "IndexError", "UnicodeDecodeError"],
+    )
+    def test_malformed_response_raises_operational_error_and_disconnects(
+        self, parse_error: Exception
+    ) -> None:
+        """Parse-layer failures must tear the connection down (parity with #138)."""
+        conn, _ = make_connected_connection()
+        frame = build_simple_ok_response(conn._cas_info)
+        conn._socket = make_socket_from_chunks([frame[:4], frame[4:]])
+
+        with patch("pycubrid.protocol.CommitPacket.parse", side_effect=parse_error):
+            with pytest.raises(OperationalError, match="malformed response from broker") as excinfo:
+                conn._send_and_receive(CommitPacket())
+
+        assert excinfo.value.__cause__ is parse_error
+        assert conn._connected is False
+        assert conn._socket is None
+
+    def test_malformed_response_then_ping_reconnects(self) -> None:
+        """After a malformed-response teardown, ping(reconnect=True) recovers."""
+        conn, _ = make_connected_connection()
+        frame = build_simple_ok_response(conn._cas_info)
+        conn._socket = make_socket_from_chunks([frame[:4], frame[4:]])
+
+        with patch("pycubrid.protocol.CommitPacket.parse", side_effect=ValueError("bad frame")):
+            with pytest.raises(OperationalError, match="malformed response from broker"):
+                conn._send_and_receive(CommitPacket())
+
+        assert conn._connected is False
+
+        def reconnect() -> None:
+            conn._socket = MagicMock()
+            conn._connected = True
+
+        conn.connect = MagicMock(side_effect=reconnect)  # type: ignore[method-assign]
+
+        assert conn.ping(reconnect=True) is True
+        conn.connect.assert_called_once_with()
+        assert conn._connected is True
+
     def test_cas_info_inactive_triggers_reconnect_on_next_request(self) -> None:
         conn, sock = make_connected_connection()
         inactive_frame = build_simple_ok_response(b"\x00\x01\x02\x03")


### PR DESCRIPTION
## Summary

Fixes #187 — the sync `Connection` was left alive (and its socket desynced) when the broker returned a malformed response, while the async path had already been hardened in #138. This PR brings the sync transport up to the same contract.

Thank you for maintaining this project — happy to adjust anything about the approach or the tests.

## Changes

- `pycubrid/connection.py`: wrap `packet.parse()` in `Connection._send_and_receive` with the same handler the async path uses — `ValueError` / `struct.error` / `IndexError` / `UnicodeDecodeError` now close the socket, set `_connected = False`, and raise `OperationalError("malformed response from broker")` with the original exception chained via `from exc`.
- `tests/test_network_edge_cases.py`: add sync parity tests mirroring `test_aio_cleanup.py`:
  - `test_malformed_response_raises_operational_error_and_disconnects` — parametrized over all four parse-error types; also asserts `__cause__` chaining.
  - `test_malformed_response_then_ping_reconnects` — verifies `ping(reconnect=True)` recovers after the teardown.

Written test-first: the new tests fail on `main` (the raw `ValueError` escapes and `_connected` stays `True`), confirming the bug before the fix.

Notes on scope:
- Server-reported errors raised inside `parse()` (`DatabaseError` subclasses via `_raise_error`) are unaffected — they don't match the handled exception types, same as in the async path.
- `OperationalError` is not an `OSError` subclass, so the new raise is not re-wrapped by the outer `except OSError` handler.
- `DATA_LENGTH` validation (negative/oversized header) is intentionally left out — that's tracked separately in #188.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Chore (maintenance, dependencies, CI, etc.)

## Checklist

- [x] My code follows the project's code style
- [x] I have run `make check` (lint + typecheck)
- [x] I have run `make test` and all tests pass (904 passed, 58 skipped; coverage 96.63%, gate 95%)
- [x] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable — no doc surface for this internal contract)
- [x] My changes do not introduce new warnings

## Related Issues

Fixes #187. Related: #138 (async fix this mirrors), #167 (transport contract lock), #188 (DATA_LENGTH validation, follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
