### PR TITLE
docs: fix cookbook repo link, polish PRD wording, add compatibility legend

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ SQLAlchemy features (ORM, Core, Alembic migrations, schema reflection) are acces
 | **CUBRID 11.2** | ✅ | -- | -- | -- | ✅ |
 | **CUBRID 11.0** | ✅ | -- | -- | -- | ✅ |
 | **CUBRID 10.2** | ✅ | -- | -- | -- | ✅ |
+> **Legend**: `✅` = executed and passing in PR CI. `--` = not executed in PR CI; verified in the nightly / release full matrix (Python 3.10–3.14 × CUBRID 10.2–11.4).
 
 CI runs the matrix above on every PR/push (Python 3.10 + 3.14 anchors × all CUBRID versions).
 The full **5 × 4** Python × CUBRID matrix runs nightly, on tagged releases, and on demand via `workflow_dispatch`.
@@ -301,7 +302,7 @@ Yes. Use `pycubrid.aio.connect()` for native asyncio support. The async surface 
 ## Related Projects
 
 - [sqlalchemy-cubrid](https://github.com/cubrid-lab/sqlalchemy-cubrid) — SQLAlchemy 2.0 dialect for CUBRID
-- [cubrid-python-cookbook](https://github.com/cubrid-lab/cubrid-python-cookbook) — Production-ready Python examples for CUBRID
+- [cubrid-cookbook-python](https://github.com/cubrid-lab/cubrid-cookbook-python) — Production-ready Python examples for CUBRID
 
 
 ## Roadmap

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -50,7 +50,7 @@ A complete pure Python implementation of the CUBRID CAS protocol:
 | PEP 249 (DB-API 2.0) compliant | ✅ | ✅ Full API compliance |
 | Offline tests (no live DB) | ✅ | ✅ 770 tests, 97.29% coverage |
 | LOB (CLOB/BLOB) support | ✅ | ✅ `create_lob()`, read/write |
-| Prepared statements | ✅ | ✅ `cursor.execute(sql, params)` — uses CAS `PREPARE_AND_EXECUTE` |
+| Prepared statements | ✅ | ✅ `cursor.execute(sql, params)` — driver-side parameter binding via `?` placeholders (see [PARAMETER_BINDING.md](PARAMETER_BINDING.md)) |
 | CI/CD with version matrix | ✅ | ✅ Py 3.10–3.14 offline + anchored integration coverage for CUBRID 10.2–11.4 |
 | Publishable to PyPI | ✅ | ✅ Release workflow on tag |
 | ≥ 95% code coverage | ✅ | ✅ 97.29% (CI-enforced) |
@@ -135,7 +135,7 @@ Standard constructors: `Date()`, `Time()`, `Timestamp()`, `Binary()`,
 - `executemany(sql, seq_of_params)` — batch execute
 - `executemany_batch(sql, seq_of_params)` — optimized batch insert
 - `fetchone()` / `fetchmany(size)` / `fetchall()` — result retrieval
-- `execute(sql, params)` — parameterized queries via CAS `PREPARE_AND_EXECUTE`
+- `execute(sql, params)` — qmark-style parameterized queries bound CLIENT-SIDE; SQL is fully rendered before being sent to CAS (see [PARAMETER_BINDING.md](PARAMETER_BINDING.md))
 - `callproc(procname, params)` — stored procedure calls
 - `nextset()` — DB-API compatibility method (returns `None`)
 - Iterator protocol — `for row in cursor`

--- a/docs/README.de.md
+++ b/docs/README.de.md
@@ -297,7 +297,7 @@ Ja. Verwenden Sie `pycubrid.aio.connect()` für native asyncio-Unterstützung. D
 ## Verwandte Projekte
 
 - [sqlalchemy-cubrid](https://github.com/cubrid-lab/sqlalchemy-cubrid) — SQLAlchemy-2.0-Dialekt für CUBRID
-- [cubrid-python-cookbook](https://github.com/cubrid-lab/cubrid-python-cookbook) — Produktionsreife Python-Beispiele für CUBRID
+- [cubrid-cookbook-python](https://github.com/cubrid-lab/cubrid-cookbook-python) — Produktionsreife Python-Beispiele für CUBRID
 
 
 ## Roadmap

--- a/docs/README.hi.md
+++ b/docs/README.hi.md
@@ -296,7 +296,7 @@ CUBRID 10.2, 11.0, 11.2, और 11.4 CI में टेस्ट किए ज�
 ## संबंधित परियोजनाएँ
 
 - [sqlalchemy-cubrid](https://github.com/cubrid-lab/sqlalchemy-cubrid) — CUBRID के लिए SQLAlchemy 2.0 dialect
-- [cubrid-python-cookbook](https://github.com/cubrid-lab/cubrid-python-cookbook) — CUBRID के लिए production-ready Python उदाहरण
+- [cubrid-cookbook-python](https://github.com/cubrid-lab/cubrid-cookbook-python) — CUBRID के लिए production-ready Python उदाहरण
 
 
 ## रोडमैप

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -296,7 +296,7 @@ CUBRID 10.2, 11.0, 11.2, 11.4를 CI에서 테스트합니다.
 ## 관련 프로젝트
 
 - [sqlalchemy-cubrid](https://github.com/cubrid-lab/sqlalchemy-cubrid) — CUBRID용 SQLAlchemy 2.0 방언
-- [cubrid-python-cookbook](https://github.com/cubrid-lab/cubrid-python-cookbook) — CUBRID를 위한 프로덕션용 Python 예제
+- [cubrid-cookbook-python](https://github.com/cubrid-lab/cubrid-cookbook-python) — CUBRID를 위한 프로덕션용 Python 예제
 
 
 ## 로드맵

--- a/docs/README.ru.md
+++ b/docs/README.ru.md
@@ -297,7 +297,7 @@ Python 3.10, 3.11, 3.12, 3.13 и 3.14.
 ## Связанные проекты
 
 - [sqlalchemy-cubrid](https://github.com/cubrid-lab/sqlalchemy-cubrid) — диалект SQLAlchemy 2.0 для CUBRID
-- [cubrid-python-cookbook](https://github.com/cubrid-lab/cubrid-python-cookbook) — готовые к продакшену примеры Python для CUBRID
+- [cubrid-cookbook-python](https://github.com/cubrid-lab/cubrid-cookbook-python) — готовые к продакшену примеры Python для CUBRID
 
 
 ## Дорожная карта

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -295,7 +295,7 @@ CUBRID 10.2、11.0、11.2 和 11.4 已在 CI 中测试。
 ## 相关项目
 
 - [sqlalchemy-cubrid](https://github.com/cubrid-lab/sqlalchemy-cubrid) — 面向 CUBRID 的 SQLAlchemy 2.0 方言
-- [cubrid-python-cookbook](https://github.com/cubrid-lab/cubrid-python-cookbook) — 面向 CUBRID 的生产级 Python 示例
+- [cubrid-cookbook-python](https://github.com/cubrid-lab/cubrid-cookbook-python) — 面向 CUBRID 的生产级 Python 示例
 
 
 ## 路线图


### PR DESCRIPTION
## Summary

- Replace `cubrid-python-cookbook` → `cubrid-cookbook-python` in README and 5 translation READMEs (the actual repo name on cubrid-lab)
- Correct misleading PRD.md wording about `PREPARE_AND_EXECUTE`: clarify that parameter binding is driver-side interpolation, not server-side prepare (PARAMETER_BINDING.md already documents the full 1.x contract)
- Add legend below Compatibility table explaining `--` entries (PR CI vs nightly/release full matrix)

## Context

- Issue #195 (cubrid-labs rename): already resolved upstream — source files on `main` are clean. Only auto-generated `pycubrid.egg-info/PKG-INFO` retains the old name (regenerates from `pyproject.toml` on install).
- Issue #196 (parameter binding docs): `docs/PARAMETER_BINDING.md` (325 lines) already exists. This PR fixes the remaining misleading references in `docs/PRD.md` (lines 53, 138).
- Issue #197 (cookbook repo name): fixed in this PR.
- Issue #198 (compatibility legend): fixed in this PR.

Closes #195
Closes #196
Closes #197
Closes #198