### PR TITLE
docs: align PRD.md example table wording with driver-side binding

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -367,7 +367,7 @@ production-ready, runnable examples for pycubrid:
 | `01_connect.py` | Basic connection and query |
 | `02_crud.py` | Create, read, update, delete operations |
 | `03_transactions.py` | Transaction management with commit/rollback |
-| `04_prepared.py` | Prepared statements for repeated queries |
+| `04_prepared.py` | Parameterized queries (driver-side binding) for repeated execution |
 | `05_error_handling.py` | Error handling with PEP 249 exception hierarchy |
 | `06_lob.py` | LOB (CLOB/BLOB) operations |
 


### PR DESCRIPTION
## Summary

Follow-up to #199 addressing a defect identified in the Oracle post-implementation review.

### Problem

`docs/PRD.md` line 370 described `04_prepared.py` as *"Prepared statements for repeated queries"*, which is inconsistent with lines 53 and 138 (updated in #199) that already clarify pycubrid does **client-side parameter binding** via `?` placeholders — not server-side `PREPARE`/`EXECUTE`.

### Fix

Update line 370 description to: *"Parameterized queries (driver-side binding) for repeated execution"*.

This aligns the example table with the driver-side binding language used elsewhere in the PRD and in `docs/PARAMETER_BINDING.md`.

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)