### PR TITLE
fix: sync parse-error exception parity + LOB write ACK verification

### DIFF
--- a/pycubrid/connection.py
+++ b/pycubrid/connection.py
@@ -477,7 +477,12 @@ class Connection(ConnectionCommonMixin):
             # Update CAS_INFO from the response (first 4 bytes).
             self._cas_info = response_body[: DataSize.CAS_INFO]
 
-            packet.parse(response_body)
+            try:
+                packet.parse(response_body)
+            except (ValueError, struct.error, IndexError, UnicodeDecodeError) as exc:
+                self._safe_close_socket()
+                self._connected = False
+                raise OperationalError("malformed response from broker") from exc
             if _LOGGER.isEnabledFor(logging.DEBUG):
                 _LOGGER.debug("recv: %d bytes", data_length + DataSize.CAS_INFO)
             return packet

--- a/pycubrid/lob.py
+++ b/pycubrid/lob.py
@@ -4,6 +4,7 @@ import logging
 from typing import Any, Protocol
 
 from .constants import CUBRIDDataType as CCI_U_TYPE
+from .exceptions import OperationalError
 from .protocol import LOBNewPacket, LOBReadPacket, LOBWritePacket
 
 
@@ -37,10 +38,18 @@ class Lob:
         return cls(connection, lob_type, packet.lob_handle)
 
     def write(self, data: bytes, offset: int = 0) -> int:
-        """Write bytes to the LOB starting from ``offset``."""
+        """Write bytes to the LOB starting from ``offset``.
+
+        Raises ``OperationalError`` if the server writes fewer bytes than
+        requested (e.g. disk full, quota exceeded).
+        """
         self._connection._ensure_connected()
         packet = LOBWritePacket(self._lob_handle, offset, data)
         self._connection._send_and_receive(packet)
+        if packet.bytes_written != len(data):
+            raise OperationalError(
+                f"LOB write truncated: wrote {packet.bytes_written} of {len(data)} bytes"
+            )
         _LOGGER.debug("LOB write: offset=%d size=%d", offset, len(data))
         return len(data)
 

--- a/pycubrid/protocol.py
+++ b/pycubrid/protocol.py
@@ -1217,6 +1217,7 @@ class LOBWritePacket:
         self.packed_lob_handle = packed_lob_handle
         self.offset = offset
         self.data = data
+        self.bytes_written: int = 0
 
     def write(self, cas_info: bytes) -> bytes:
         """Serialize the LOB write request."""
@@ -1228,13 +1229,17 @@ class LOBWritePacket:
         return writer.finalize(cas_info)
 
     def parse(self, data: bytes | bytearray) -> None:
-        """Parse the LOB write response."""
+        """Parse the LOB write response.
+
+        On success, ``response_code`` doubles as ``bytes_written`` per CAS protocol.
+        """
         reader = PacketReader(data)
         reader._skip_bytes(DataSize.CAS_INFO)
         response_code = reader._parse_int()
         if response_code < 0:
             remaining = len(data) - 8
             _raise_error(reader, remaining)
+        self.bytes_written = response_code
 
 
 class LOBReadPacket:

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -491,6 +491,32 @@ class TestErrorHandling:
         assert conn._connected is False
         assert conn._socket is None
 
+    def test_send_and_receive_converts_parse_error_to_operational_error(
+        self,
+        socket_queue: list[MagicMock],
+    ) -> None:
+        """Parse errors (struct.error, ValueError, etc.) become OperationalError."""
+        conn, sock = make_connected_connection(socket_queue)
+
+        # Provide valid framing data for the recv path
+        body = conn._cas_info + struct.pack(">i", 0)
+        frame = struct.pack(">i", len(body) - 4) + body
+        sock.recv.side_effect = list(sock.recv.side_effect) + [
+            frame[:4],
+            frame[4:8],
+            frame[8:],
+        ]
+
+        with patch(
+            "pycubrid.protocol.CommitPacket.parse",
+            side_effect=struct.error("malformed packet header"),
+        ):
+            with pytest.raises(OperationalError, match="malformed response from broker"):
+                conn.commit()
+
+        assert conn._connected is False
+        assert conn._socket is None
+
     def test_send_and_receive_raises_interface_error_when_socket_none(
         self,
         socket_queue: list[MagicMock],

--- a/tests/test_lob.py
+++ b/tests/test_lob.py
@@ -16,6 +16,8 @@ def mock_connection() -> MagicMock:
     connection._ensure_connected = MagicMock()
 
     def send_and_receive(packet: object) -> object:
+        if isinstance(packet, LOBWritePacket):
+            packet.bytes_written = len(packet.data)
         return packet
 
     connection._send_and_receive = MagicMock(side_effect=send_and_receive)
@@ -87,6 +89,32 @@ def test_write_propagates_connection_closed_error(mock_connection: MagicMock) ->
 
     with pytest.raises(InterfaceError, match="connection is closed"):
         lob.write(b"x")
+
+
+def test_write_raises_on_partial_write(mock_connection: MagicMock) -> None:
+    """Server writing fewer bytes than requested raises OperationalError."""
+    lob = Lob(mock_connection, CUBRIDDataType.BLOB, b"lob-handle")
+
+    def partial_write(packet: object) -> object:
+        if isinstance(packet, LOBWritePacket):
+            packet.bytes_written = 2  # Only 2 of 5 bytes written
+        return packet
+
+    mock_connection._send_and_receive.side_effect = partial_write
+
+    with pytest.raises(OperationalError, match="LOB write truncated"):
+        lob.write(b"hello")
+
+
+def test_write_raises_on_zero_bytes_written(mock_connection: MagicMock) -> None:
+    """Server writing zero bytes raises OperationalError with count."""
+    lob = Lob(mock_connection, CUBRIDDataType.BLOB, b"lob-handle")
+
+    # Override fixture: don't set bytes_written (stays 0 from __init__)
+    mock_connection._send_and_receive.side_effect = lambda packet: packet
+
+    with pytest.raises(OperationalError, match="wrote 0 of 5 bytes"):
+        lob.write(b"hello")
 
 
 def test_read_sends_lob_read_packet_and_returns_data(mock_connection: MagicMock) -> None:

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1293,6 +1293,14 @@ class TestLOBWritePacket:
         pkt = LOBWritePacket(b"", 0, b"")
         response = _build_success_response(DEFAULT_CAS_INFO, 0)
         pkt.parse(response)
+        assert pkt.bytes_written == 0
+
+    def test_parse_success_extracts_bytes_written(self) -> None:
+        """response_code doubles as bytes_written per CAS protocol."""
+        pkt = LOBWritePacket(b"", 0, b"hello")
+        response = _build_success_response(DEFAULT_CAS_INFO, 5)
+        pkt.parse(response)
+        assert pkt.bytes_written == 5
 
     def test_parse_error(self) -> None:
         pkt = LOBWritePacket(b"", 0, b"")


### PR DESCRIPTION
## Summary

Two P0 safety fixes for pycubrid v1.5.1:

### P0-1: Sync parse-error exception parity (#201)

`connection.py:_send_and_receive` caught only `OSError`. The async path catches `(ValueError, struct.error, IndexError, UnicodeDecodeError)` around `packet.parse()`. A malformed broker response could raise `struct.error`, bypass cleanup, and leave the connection in a dirty state.

**Fix**: Added inner `try/except` around `packet.parse()` matching the async pattern. Parse errors now close the socket, set `_connected = False`, and raise `OperationalError("malformed response from broker")`.

### P0-3: LOB write ACK verification (#202)

`Lob.write()` returned `len(data)` unconditionally, ignoring the server response. If the server wrote fewer bytes (disk full, quota), the caller never knew — silent data truncation.

**Fix**: `LOBWritePacket.parse()` now extracts `bytes_written` from the CAS response (`response_code` doubles as bytes_written on success, matching `LOBReadPacket`'s existing pattern). `Lob.write()` compares `bytes_written` vs `len(data)` and raises `OperationalError` on mismatch.

## Test plan

- [x] 903 offline tests pass (58 integration skipped)
- [x] Coverage: 96.64% (threshold 95% maintained)
- [x] New tests added (parse error, partial write, zero write, bytes_written extraction)
- [x] ruff check + format clean
- [x] mypy clean

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)
Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>