### PR TITLE
release: v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.5.1] - 2026-07-18
+
+### Fixed
+- **Sync `_send_and_receive` parse-error exception parity (#201)** — the sync connection path at `connection.py:_send_and_receive` previously caught only `OSError`, meaning malformed CAS broker responses that raised `struct.error`, `ValueError`, `IndexError`, or `UnicodeDecodeError` would bypass socket cleanup and leave the connection in a dirty state for reuse. The async path at `aio/connection.py:615-621` already handled these. Ported the full exception catch list to the sync path so parse errors now close the socket, mark `_connected = False`, and raise `OperationalError("malformed response from broker")` with the original cause chained.
+- **LOB write server ACK verification (#202)** — `Lob.write()` returned `len(data)` unconditionally without checking whether the server actually wrote all the bytes. Under disk-full / quota-exceeded conditions, the server could write fewer bytes and the caller would never know — silent data truncation. `LOBWritePacket.parse()` now extracts `bytes_written` from the CAS response (the response code doubles as the byte count on success, matching `LOBReadPacket`'s existing pattern). `Lob.write()` compares `bytes_written` against `len(data)` and raises `OperationalError` on mismatch.
+
 ## [Unreleased]
 
 ## [1.5.0] - 2026-05-23

--- a/pycubrid/__init__.py
+++ b/pycubrid/__init__.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     from pycubrid.connection import Connection
     from pycubrid.timing import TimingStats
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"
 
 # PEP 249 module-level attributes
 apilevel = "2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pycubrid"
-version = "1.5.0"
+version = "1.5.1"
 description = "Pure Python DB-API 2.0 driver for CUBRID database"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## v1.5.1 — Patch Release

### Fixed
- **P0**: Sync `_send_and_receive` parse-error exception parity (#201)
- **P0**: LOB write server ACK verification (#202)

See [CHANGELOG.md](https://github.com/cubrid-lab/pycubrid/blob/release/v1.5.1/CHANGELOG.md) for full details.

Tag `v1.5.1` already pushed. PyPI publish workflow will trigger on merge.