### PR TITLE
fix: executemany batch error handling and DATA_LENGTH validation (#186, #188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.6.1] - 2026-07-18
+
+### Fixed
+- **`executemany()` batch error handling (#186)** — `executemany_batch()` in both sync `Cursor` and `AsyncCursor` consumed `packet.results` but never checked `packet.errors`, silently swallowing per-statement batch failures. Partial failures (e.g. one INSERT in a batch of 10 hits a unique constraint violation) were invisible to the caller — data integrity risk. Now raises the first batch error using the same CAS error code dispatch as `protocol._raise_error()` (PR #208), mapping to the correct PEP 249 exception class (IntegrityError, ProgrammingError, OperationalError, etc.).
+- **DATA_LENGTH broker response validation (#188)** — `_send_and_receive()` in both sync `Connection` and `AsyncConnection` unpacked the 4-byte `DATA_LENGTH` header and immediately allocated `bytearray(data_length)` without bounds checking. A malformed or hostile broker response with a negative value would raise a raw `ValueError` from `bytearray()`, and an oversized value could trigger unbounded memory allocation (OOM). Added `_validate_data_length()` that rejects negative values and values exceeding `DataSize.MAX_PACKET_SIZE` (256 MiB) with a clean `OperationalError`, applied at both the handshake and main send/receive paths.
+
 ## [1.6.0] - 2026-07-18
 
 ### Fixed

--- a/pycubrid/__init__.py
+++ b/pycubrid/__init__.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     from pycubrid.connection import Connection
     from pycubrid.timing import TimingStats
 
-__version__ = "1.6.0"
+__version__ = "1.6.1"
 
 # PEP 249 module-level attributes
 apilevel = "2.0"

--- a/pycubrid/aio/connection.py
+++ b/pycubrid/aio/connection.py
@@ -217,6 +217,7 @@ class AsyncConnection(ConnectionCommonMixin):
         await self._writer.drain()
         data_length_bytes = await self._recv_exact(self._reader, DataSize.DATA_LENGTH)
         data_length = struct.unpack(">i", data_length_bytes)[0]
+        self._validate_data_length(data_length)
         response_body = await self._recv_exact(self._reader, data_length + DataSize.CAS_INFO)
         open_db_packet.parse(response_body)
 
@@ -610,6 +611,7 @@ class AsyncConnection(ConnectionCommonMixin):
 
         data_length_bytes = await self._recv_exact(reader, DataSize.DATA_LENGTH)
         data_length = struct.unpack(">i", data_length_bytes)[0]
+        self._validate_data_length(data_length)
         response_body = await self._recv_exact(reader, data_length + DataSize.CAS_INFO)
 
         self._cas_info = response_body[: DataSize.CAS_INFO]
@@ -620,6 +622,21 @@ class AsyncConnection(ConnectionCommonMixin):
             self._connected = False
             raise OperationalError("malformed response from broker") from exc
         return packet
+
+    @staticmethod
+    def _validate_data_length(data_length: int) -> None:
+        """Validate the DATA_LENGTH header from the broker.
+
+        Raises OperationalError for negative or oversized values to prevent
+        ValueError on allocation or unbounded memory usage (issue #188).
+        """
+        if data_length < 0:
+            raise OperationalError(f"invalid DATA_LENGTH from broker: {data_length} (negative)")
+        if data_length > DataSize.MAX_PACKET_SIZE:
+            raise OperationalError(
+                f"invalid DATA_LENGTH from broker: {data_length} "
+                f"(exceeds max {DataSize.MAX_PACKET_SIZE})"
+            )
 
     async def _recv_exact(
         self,

--- a/pycubrid/aio/cursor.py
+++ b/pycubrid/aio/cursor.py
@@ -48,7 +48,7 @@ def _raise_batch_error(err: dict[str, Any]) -> None:
         "DatabaseError": DatabaseError,
     }
     exc_cls = exc_map.get(exc_name, DatabaseError)
-    raise exc_cls(message, sqlstate)
+    raise exc_cls(message, code=code, sqlstate=sqlstate)
 
 
 class AsyncCursor(CursorParamsMixin):

--- a/pycubrid/aio/cursor.py
+++ b/pycubrid/aio/cursor.py
@@ -13,7 +13,8 @@ from pycubrid._cursor_common import (
     extract_first_keyword,
 )
 from pycubrid.constants import CUBRIDStatementType
-from pycubrid.exceptions import InterfaceError, OperationalError, ProgrammingError
+from pycubrid.exceptions import DatabaseError, InterfaceError, OperationalError, ProgrammingError
+from pycubrid.error_codes import CAS_ERROR_TO_EXCEPTION, _DEFAULT_SQLSTATE
 from pycubrid.protocol import (
     BatchExecutePacket,
     CloseQueryPacket,
@@ -24,6 +25,30 @@ from pycubrid.protocol import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _raise_batch_error(err: dict[str, Any]) -> None:
+    """Raise the appropriate PEP 249 exception for a batch statement failure."""
+    code = err.get("code", -1)
+    message = err.get("message", "batch execute statement failed")
+    exc_name = CAS_ERROR_TO_EXCEPTION.get(code, "DatabaseError")
+    sqlstate = _DEFAULT_SQLSTATE.get(exc_name, "HY000")
+    from pycubrid.exceptions import (
+        DataError,
+        IntegrityError,
+        InternalError,
+    )
+
+    exc_map = {
+        "DataError": DataError,
+        "IntegrityError": IntegrityError,
+        "InternalError": InternalError,
+        "OperationalError": OperationalError,
+        "ProgrammingError": ProgrammingError,
+        "DatabaseError": DatabaseError,
+    }
+    exc_cls = exc_map.get(exc_name, DatabaseError)
+    raise exc_cls(message, sqlstate)
 
 
 class AsyncCursor(CursorParamsMixin):
@@ -214,6 +239,11 @@ class AsyncCursor(CursorParamsMixin):
             protocol_version=self._connection._protocol_version,
         )
         await self._connection._send_and_receive(packet)
+
+        # Raise on per-statement batch failures (issue #186).
+        if packet.errors:
+            err = packet.errors[0]
+            _raise_batch_error(err)
 
         self._description = None
         self._rows = []

--- a/pycubrid/connection.py
+++ b/pycubrid/connection.py
@@ -150,6 +150,7 @@ class Connection(ConnectionCommonMixin):
             self._socket.sendall(open_db_packet.write())
             data_length_bytes = self._recv_exact(self._socket, DataSize.DATA_LENGTH)
             data_length = struct.unpack(">i", data_length_bytes)[0]
+            self._validate_data_length(data_length)
             response_body = self._recv_exact(self._socket, data_length + DataSize.CAS_INFO)
             open_db_packet.parse(response_body)
 
@@ -472,6 +473,7 @@ class Connection(ConnectionCommonMixin):
 
             data_length_bytes = self._recv_exact(self._socket, DataSize.DATA_LENGTH)
             data_length = struct.unpack(">i", data_length_bytes)[0]
+            self._validate_data_length(data_length)
             response_body = self._recv_exact(self._socket, data_length + DataSize.CAS_INFO)
 
             # Update CAS_INFO from the response (first 4 bytes).
@@ -490,6 +492,21 @@ class Connection(ConnectionCommonMixin):
             self._safe_close_socket()
             self._connected = False
             raise OperationalError("socket communication failed") from exc
+
+    @staticmethod
+    def _validate_data_length(data_length: int) -> None:
+        """Validate the DATA_LENGTH header from the broker.
+
+        Raises OperationalError for negative or oversized values to prevent
+        ValueError on allocation or unbounded memory usage (issue #188).
+        """
+        if data_length < 0:
+            raise OperationalError(f"invalid DATA_LENGTH from broker: {data_length} (negative)")
+        if data_length > DataSize.MAX_PACKET_SIZE:
+            raise OperationalError(
+                f"invalid DATA_LENGTH from broker: {data_length} "
+                f"(exceeds max {DataSize.MAX_PACKET_SIZE})"
+            )
 
     def _recv_exact(self, sock: socket.socket, size: int) -> bytearray:
         """Receive exactly ``size`` bytes from the socket."""

--- a/pycubrid/constants.py
+++ b/pycubrid/constants.py
@@ -430,8 +430,6 @@ class DataSize:
     #: negative or oversized DATA_LENGTH values from a malformed / hostile
     #: broker response (issue #188).
     MAX_PACKET_SIZE: int = 268_435_456
-    DATA_LENGTH: int = 4
-    CAS_INFO: int = 4
 
 
 # ---------------------------------------------------------------------------

--- a/pycubrid/constants.py
+++ b/pycubrid/constants.py
@@ -426,6 +426,13 @@ class DataSize:
     DATA_LENGTH: int = 4
     CAS_INFO: int = 4
 
+    #: Maximum acceptable packet body size (256 MiB). Guards against
+    #: negative or oversized DATA_LENGTH values from a malformed / hostile
+    #: broker response (issue #188).
+    MAX_PACKET_SIZE: int = 268_435_456
+    DATA_LENGTH: int = 4
+    CAS_INFO: int = 4
+
 
 # ---------------------------------------------------------------------------
 # Common CUBRID Error Codes

--- a/pycubrid/cursor.py
+++ b/pycubrid/cursor.py
@@ -63,7 +63,7 @@ def _raise_batch_error(err: dict[str, Any]) -> None:
         "DatabaseError": DatabaseError,
     }
     exc_cls = exc_map.get(exc_name, DatabaseError)
-    raise exc_cls(message, sqlstate)
+    raise exc_cls(message, code=code, sqlstate=sqlstate)
 
 
 class Cursor(CursorParamsMixin):

--- a/pycubrid/cursor.py
+++ b/pycubrid/cursor.py
@@ -14,7 +14,8 @@ from ._cursor_common import (
     extract_first_keyword,
     split_on_placeholders,
 )
-from .exceptions import InterfaceError, OperationalError, ProgrammingError
+from .exceptions import DatabaseError, InterfaceError, OperationalError, ProgrammingError
+from .error_codes import CAS_ERROR_TO_EXCEPTION, _DEFAULT_SQLSTATE
 from .protocol import (
     BatchExecutePacket,
     CloseQueryPacket,
@@ -33,6 +34,36 @@ _extract_first_keyword = extract_first_keyword
 _split_on_placeholders = split_on_placeholders
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _raise_batch_error(err: dict[str, Any]) -> None:
+    """Raise the appropriate PEP 249 exception for a batch statement failure.
+
+    Uses CAS error code dispatch (same mapping as protocol._raise_error)
+    to select the correct exception class. Falls back to DatabaseError
+    for unknown codes.
+    """
+    code = err.get("code", -1)
+    message = err.get("message", "batch execute statement failed")
+    exc_name = CAS_ERROR_TO_EXCEPTION.get(code, "DatabaseError")
+    sqlstate = _DEFAULT_SQLSTATE.get(exc_name, "HY000")
+    # Import here to avoid circular import at module load time.
+    from .exceptions import (
+        DataError,
+        IntegrityError,
+        InternalError,
+    )
+
+    exc_map = {
+        "DataError": DataError,
+        "IntegrityError": IntegrityError,
+        "InternalError": InternalError,
+        "OperationalError": OperationalError,
+        "ProgrammingError": ProgrammingError,
+        "DatabaseError": DatabaseError,
+    }
+    exc_cls = exc_map.get(exc_name, DatabaseError)
+    raise exc_cls(message, sqlstate)
 
 
 class Cursor(CursorParamsMixin):
@@ -260,6 +291,13 @@ class Cursor(CursorParamsMixin):
             protocol_version=self._connection._protocol_version,
         )
         self._connection._send_and_receive(packet)
+
+        # Raise on per-statement batch failures (issue #186).
+        # The batch protocol returns partial results alongside per-statement
+        # errors; previously the errors were silently swallowed.
+        if packet.errors:
+            err = packet.errors[0]
+            _raise_batch_error(err)
 
         self._description = None
         self._rows = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pycubrid"
-version = "1.6.0"
+version = "1.6.1"
 description = "Pure Python DB-API 2.0 driver for CUBRID database"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -659,6 +659,40 @@ class TestAsyncCursorExecutemanyBatch:
         await cur.executemany_batch(["INSERT 1"], auto_commit=True)
         assert captured["auto_commit"] is True
 
+    @pytest.mark.asyncio
+    async def test_executemany_batch_raises_on_partial_failure(self) -> None:
+        """Batch execute must raise when a statement fails (#186)."""
+        from pycubrid.exceptions import IntegrityError
+
+        conn = _make_mock_conn()
+        cur = AsyncCursor(conn)
+
+        async def fake_send(packet):
+            packet.results = [(0, 1)]
+            packet.errors = [{"code": -670, "message": "unique constraint violation"}]
+
+        conn._send_and_receive = AsyncMock(side_effect=fake_send)
+
+        with pytest.raises(IntegrityError, match="unique constraint"):
+            await cur.executemany_batch(["INSERT INTO t VALUES (1)", "INSERT INTO t VALUES (1)"])
+
+    @pytest.mark.asyncio
+    async def test_executemany_batch_error_dispatches_operational_error(self) -> None:
+        """Batch errors with operational CAS codes dispatch to OperationalError (#186)."""
+        from pycubrid.exceptions import OperationalError as AsyncOperationalError
+
+        conn = _make_mock_conn()
+        cur = AsyncCursor(conn)
+
+        async def fake_send(packet):
+            packet.results = []
+            packet.errors = [{"code": -11, "message": "handle is closed"}]
+
+        conn._send_and_receive = AsyncMock(side_effect=fake_send)
+
+        with pytest.raises(AsyncOperationalError, match="handle is closed"):
+            await cur.executemany_batch(["SELECT 1"])
+
 
 class TestAsyncCursorFetchMore:
     @pytest.mark.asyncio

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -496,6 +496,59 @@ def test_executemany_batch_closed_cursor_raises(cursor: Cursor) -> None:
         cursor.executemany_batch(["SELECT 1"])
 
 
+def test_executemany_batch_raises_on_partial_failure(
+    cursor: Cursor, mock_connection: MagicMock
+) -> None:
+    """Batch execute must raise when a statement in the batch fails (#186)."""
+    from pycubrid.exceptions import IntegrityError
+
+    def send(packet: object) -> object:
+        if isinstance(packet, BatchExecutePacket):
+            packet.results = [(0, 1)]  # first statement succeeded
+            packet.errors = [{"code": -670, "message": "unique constraint violation"}]
+        return packet
+
+    mock_connection._send_and_receive.side_effect = send
+
+    with pytest.raises(IntegrityError, match="unique constraint"):
+        cursor.executemany_batch(["INSERT INTO t VALUES (1)", "INSERT INTO t VALUES (1)"])
+
+
+def test_executemany_batch_error_uses_cas_code_dispatch(
+    cursor: Cursor, mock_connection: MagicMock
+) -> None:
+    """Batch errors dispatch to the correct PEP 249 class via CAS code (#186)."""
+    from pycubrid.exceptions import ProgrammingError
+
+    def send(packet: object) -> object:
+        if isinstance(packet, BatchExecutePacket):
+            packet.results = []
+            packet.errors = [{"code": -494, "message": "syntax error near 'SELCT'"}]
+        return packet
+
+    mock_connection._send_and_receive.side_effect = send
+
+    with pytest.raises(ProgrammingError, match="syntax error"):
+        cursor.executemany_batch(["SELCT 1"])
+
+
+def test_executemany_batch_no_errors_still_works(
+    cursor: Cursor, mock_connection: MagicMock
+) -> None:
+    """Ensure the error check doesn't affect the normal happy path (#186)."""
+
+    def send(packet: object) -> object:
+        if isinstance(packet, BatchExecutePacket):
+            packet.results = [(0, 5), (0, 3)]
+            packet.errors = []
+        return packet
+
+    mock_connection._send_and_receive.side_effect = send
+    result = cursor.executemany_batch(["INSERT 1", "INSERT 2"])
+    assert result == [(0, 5), (0, 3)]
+    assert cursor.rowcount == 8
+
+
 def test_close_sends_close_query_and_removes_cursor(
     cursor: Cursor, mock_connection: MagicMock
 ) -> None:

--- a/tests/test_network_edge_cases.py
+++ b/tests/test_network_edge_cases.py
@@ -9,6 +9,7 @@ import pytest
 
 from pycubrid.aio.connection import AsyncConnection
 from pycubrid.connection import Connection
+from pycubrid.constants import DataSize
 from pycubrid.exceptions import OperationalError
 from pycubrid.protocol import CommitPacket
 
@@ -190,6 +191,38 @@ class TestConnectionNetworkEdgeCases:
             Connection("localhost", 33000, "testdb", "dba", "", read_timeout=4.5)
 
         sock.settimeout.assert_called_once_with(4.5)
+
+
+class TestDataLengthValidation:
+    """Tests for DATA_LENGTH bounds checking (issue #188)."""
+
+    def test_negative_data_length_raises_operational_error(self) -> None:
+        """A negative DATA_LENGTH from the broker must raise OperationalError, not ValueError."""
+        with pytest.raises(OperationalError, match="negative"):
+            Connection._validate_data_length(-1)
+
+    def test_oversized_data_length_raises_operational_error(self) -> None:
+        """An oversized DATA_LENGTH must raise OperationalError, not allocate unbounded memory."""
+        with pytest.raises(OperationalError, match="exceeds max"):
+            Connection._validate_data_length(DataSize.MAX_PACKET_SIZE + 1)
+
+    def test_zero_data_length_is_accepted(self) -> None:
+        """Zero is a valid DATA_LENGTH (empty response body)."""
+        Connection._validate_data_length(0)  # should not raise
+
+    def test_max_packet_size_is_accepted(self) -> None:
+        """The exact boundary value should be accepted."""
+        Connection._validate_data_length(DataSize.MAX_PACKET_SIZE)  # should not raise
+
+    def test_async_negative_data_length_raises_operational_error(self) -> None:
+        """Async connection must also validate DATA_LENGTH (#188)."""
+        with pytest.raises(OperationalError, match="negative"):
+            AsyncConnection._validate_data_length(-1)
+
+    def test_async_oversized_data_length_raises_operational_error(self) -> None:
+        """Async connection must reject oversized DATA_LENGTH (#188)."""
+        with pytest.raises(OperationalError, match="exceeds max"):
+            AsyncConnection._validate_data_length(DataSize.MAX_PACKET_SIZE + 1)
 
 
 class TestAsyncConnectionNetworkEdgeCases:


### PR DESCRIPTION
## Summary

Two bug fixes for pycubrid that address why these issues weren't caught by the existing test suite:

### #186 — `executemany()` silently swallows per-statement batch errors

`executemany_batch()` consumed `packet.results` but never checked `packet.errors`. Partial failures (e.g., one INSERT in a batch of 10 hits a unique constraint violation) were invisible to the caller — **data integrity risk**.

**Root cause of test gap**: All 9 existing `executemany_batch` tests mocked `_send_and_receive` and only set `packet.results`. None ever set `packet.errors`, so the swallowing behavior was never exercised.

**Fix**: Added `if packet.errors: _raise_batch_error(err)` after `_send_and_receive()`. The `_raise_batch_error` helper uses the same `CAS_ERROR_TO_EXCEPTION` dispatch from PR #208 to map to the correct PEP 249 exception class.

### #188 — DATA_LENGTH from broker is not validated

`_send_and_receive()` unpacked the 4-byte `DATA_LENGTH` header and immediately allocated `bytearray(data_length)` without bounds checking. A negative value → raw `ValueError`. An oversized value → unbounded memory allocation (OOM).

**Root cause of test gap**: All connection tests mock `_send_and_receive` itself, bypassing the raw socket `_recv_exact` path entirely. No test ever injected a malformed DATA_LENGTH header.

**Fix**: Added `_validate_data_length()` static method on both `Connection` and `AsyncConnection`, called after `struct.unpack` at both the handshake and main send/receive paths. Rejects negative values and values exceeding `DataSize.MAX_PACKET_SIZE` (256 MiB).

## Test plan

- [x] 3 new sync batch error tests: partial failure raises IntegrityError, CAS code dispatch to ProgrammingError, happy path unaffected
- [x] 2 new async batch error tests: partial failure raises IntegrityError, CAS code dispatch to OperationalError
- [x] 6 new DATA_LENGTH validation tests: negative (sync+async), oversized (sync+async), zero accepted, boundary accepted
- [x] All 931 offline tests pass (was 920 before this PR)
- [x] `ruff check` + `ruff format` clean

Closes #186, #188

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)