### PR TITLE
fix: quote mermaid labels to fix GitHub rendering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,13 +17,13 @@ or native CCI library.
 
 ```mermaid
 graph TD
-    root[pycubrid/ - Main package (9 modules)]
-    init[__init__.py - Public API, PEP 249 globals, connect(), exports]
-    exceptions[exceptions.py - Full PEP 249 exception hierarchy (10 classes)]
+    root["pycubrid/ - Main package (9 modules)"]
+    init["__init__.py - Public API, PEP 249 globals, connect(), exports"]
+    exceptions["exceptions.py - Full PEP 249 exception hierarchy (10 classes)"]
     types[types.py - PEP 249 type objects and constructors]
     constants[constants.py - CAS protocol constants]
     packet[packet.py - PacketReader/PacketWriter binary serialization]
-    protocol[protocol.py - CAS protocol packets (18 packet classes)]
+    protocol["protocol.py - CAS protocol packets (18 packet classes)"]
     connection[connection.py - PEP 249 Connection class]
     cursor[cursor.py - PEP 249 Cursor class]
     lob[lob.py - LOB support]
@@ -194,7 +194,7 @@ graph TD
     test_cursor[test_cursor.py - Cursor class]
     test_lob[test_lob.py - LOB support]
     test_init[test_init.py - Module-level API tests]
-    test_integration[test_integration.py - Live DB tests (requires Docker)]
+    test_integration["test_integration.py - Live DB tests (requires Docker)"]
     test_pep249[test_pep249.py - Full PEP 249 compliance]
 
     tests --> conftest
@@ -218,7 +218,7 @@ graph TD
     docs[docs/]
     connection[CONNECTION.md - Connection strings, URL format, configuration]
     types[TYPES.md - Full type mapping, CUBRID-specific types]
-    binding[PARAMETER_BINDING.md - Driver-side literal binding contract: per-type SQL mapping, escaping, non-guarantees]
+    binding["PARAMETER_BINDING.md - Driver-side literal binding contract: per-type SQL mapping, escaping, non-guarantees"]
     api[API_REFERENCE.md - Complete API documentation]
     protocol[PROTOCOL.md - CAS wire protocol reference]
     development[DEVELOPMENT.md - Dev setup, testing, Docker, coverage, CI/CD]

--- a/README.md
+++ b/README.md
@@ -230,13 +230,13 @@ graph TD
 ```mermaid
 graph TD
     root[pycubrid/]
-    init[__init__.py - Public API connect(), types, exceptions, __version__]
+    init["__init__.py - Public API connect(), types, exceptions, __version__"]
     connection[connection.py - Connection class connect/commit/rollback/cursor/LOB]
     cursor[cursor.py - Cursor class execute/fetch/executemany/callproc/iterator]
     types[types.py - DB-API 2.0 type objects and constructors]
     exceptions[exceptions.py - PEP 249 exception hierarchy]
     constants[constants.py - CAS function codes, data types, protocol constants]
-    protocol[protocol.py - CAS wire protocol packet classes (18 packet types)]
+    protocol["protocol.py - CAS wire protocol packet classes (18 packet types)"]
     packet[packet.py - Low-level packet reader/writer]
     lob[lob.py - LOB support]
     typed[py.typed - PEP 561 marker]
@@ -252,7 +252,7 @@ graph TD
     root --> lob
     root --> typed
     root --> aio
-    aio[aio/ - AsyncConnection, AsyncCursor, async connect()]
+    aio["aio/ - AsyncConnection, AsyncCursor, async connect()"]
 ```
 
 ## FAQ

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -64,7 +64,7 @@ make install
 graph TD
     root[pycubrid/]
 
-    pkg[pycubrid/ - Main package (9 modules)]
+    pkg["pycubrid/ - Main package (9 modules)"]
     tests[tests/ - Test suite]
     docs[docs/ - Documentation]
     pyproject[pyproject.toml - Package configuration]
@@ -87,17 +87,17 @@ graph TD
     root --> readme
 
     pkg --> init[__init__.py - Public API, PEP 249 module attributes]
-    pkg --> connection[connection.py - Connection class (TCP, CAS handshake)]
-    pkg --> cursor[cursor.py - Cursor class (execute, fetch, iterate)]
+    pkg --> connection["connection.py - Connection class (TCP, CAS handshake)"]
+    pkg --> cursor["cursor.py - Cursor class (execute, fetch, iterate)"]
     pkg --> types[types.py - PEP 249 type objects and constructors]
     pkg --> exceptions[exceptions.py - Full PEP 249 exception hierarchy]
-    pkg --> constants[constants.py - CAS protocol enums (41 function codes, 27+ types)]
-    pkg --> protocol[protocol.py - 18 packet classes (serialize/deserialize)]
+    pkg --> constants["constants.py - CAS protocol enums (41 function codes, 27+ types)"]
+    pkg --> protocol["protocol.py - 18 packet classes (serialize/deserialize)"]
     pkg --> packet[packet.py - PacketWriter + PacketReader primitives]
-    pkg --> lob[lob.py - LOB (BLOB/CLOB) support]
+    pkg --> lob["lob.py - LOB (BLOB/CLOB) support"]
     pkg --> typed[py.typed - PEP 561 marker]
 
-    tests --> conftest[conftest.py - Shared fixtures (mock connection, mock socket)]
+    tests --> conftest["conftest.py - Shared fixtures (mock connection, mock socket)"]
     tests --> test_connection[test_connection.py - Connection lifecycle tests]
     tests --> test_cursor[test_cursor.py - Cursor operations tests]
     tests --> test_types[test_types.py - Type object tests]
@@ -107,7 +107,7 @@ graph TD
     tests --> test_packet[test_packet.py - PacketWriter/PacketReader tests]
     tests --> test_lob[test_lob.py - LOB tests]
     tests --> test_pep249[test_pep249.py - PEP 249 compliance tests]
-    tests --> test_integration[test_integration.py - Live DB integration tests (requires Docker)]
+    tests --> test_integration["test_integration.py - Live DB integration tests (requires Docker)"]
     tests --> test_suite[test_suite.py - Extended test suite]
 
     docs --> doc_connection[CONNECTION.md - Connection guide]

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -25,7 +25,7 @@ flowchart LR
     App[Python Application] --> Driver[pycubrid\nPure Python DBAPI2]
     Driver --> CAS[CAS Binary Protocol over TCP]
     CAS --> Broker[CUBRID Broker / CAS]
-    Broker --> Server[(CUBRID Server)]
+    Broker --> Server["(CUBRID Server)"]
 ```
 
 ```mermaid
@@ -106,7 +106,7 @@ without hardcoding thresholds that age badly.
 flowchart TD
     Detect[cubrid-benchmark detects gap] --> Issue[File a Performance issue\nusing the issue template]
     Issue --> Profile[Run profiling scripts\nto isolate the hot path]
-    Profile --> Optimize[Apply targeted fix\n(see Optimization Tips)]
+    Profile --> Optimize["Apply targeted fix\n(see Optimization Tips)"]
     Optimize --> Verify[Re-run profiling scripts\nand cubrid-benchmark]
     Verify --> Close[Attach results to issue\nand close]
 ```

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -66,13 +66,13 @@ A complete pure Python implementation of the CUBRID CAS protocol:
 ```mermaid
 graph TD
     root[pycubrid/ - 10 modules]
-    init[__init__.py - Public API connect(), types, exceptions, __version__]
+    init["__init__.py - Public API connect(), types, exceptions, __version__"]
     connection[connection.py - Connection class connect/commit/rollback/cursor/LOB]
     cursor[cursor.py - Cursor class execute/fetch/executemany/callproc/iterator]
     types[types.py - DB-API 2.0 type objects and constructors]
     exceptions[exceptions.py - PEP 249 exception hierarchy]
     constants[constants.py - CAS function codes, data types, protocol constants]
-    protocol[protocol.py - CAS wire protocol packet classes (18 packet types)]
+    protocol["protocol.py - CAS wire protocol packet classes (18 packet types)"]
     packet[packet.py - Low-level packet reader/writer]
     lob[lob.py - LOB support]
     typed[py.typed - PEP 561 marker]
@@ -285,9 +285,9 @@ pycubrid is the foundational driver in the cubrid-lab Python ecosystem:
 
 ```mermaid
 graph TD
-    pycubrid[pycubrid (DB-API 2.0 driver)]
-    sqlalchemy[sqlalchemy-cubrid (SQLAlchemy 2.0 dialect)]
-    cookbook[cubrid-cookbook (runnable examples)]
+    pycubrid["pycubrid (DB-API 2.0 driver)"]
+    sqlalchemy["sqlalchemy-cubrid (SQLAlchemy 2.0 dialect)"]
+    cookbook["cubrid-cookbook (runnable examples)"]
     fastapi[FastAPI examples]
     django[Django examples]
     flask[Flask examples]

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -59,7 +59,7 @@ Key characteristics:
 
 ```mermaid
 graph LR
-    client[Client (pycubrid)] -- TCP port 33000 --> broker[Broker]
+    client["Client (pycubrid)"] -- TCP port 33000 --> broker[Broker]
     broker --> cas[CAS Process]
     cas --> db[CUBRID Database]
 ```
@@ -77,8 +77,8 @@ All packets after the initial handshake use the following frame format:
 
 ```mermaid
 graph LR
-    data[Data Length (4B) big-endian int32] --> casinfo[CAS Info (4B) session state]
-    casinfo --> payload[Payload (variable) function-specific]
+    data["Data Length (4B) big-endian int32"] --> casinfo["CAS Info (4B) session state"]
+    casinfo --> payload["Payload (variable) function-specific"]
 ```
 
 | Field       | Size    | Description |
@@ -581,7 +581,7 @@ When `response_code < 0`, the response contains an error:
 
 ```mermaid
 graph LR
-    code[Error Code (4B int)] --> message[Error Message (null-terminated string)]
+    code["Error Code (4B int)"] --> message["Error Message (null-terminated string)"]
 ```
 
 pycubrid classifies errors automatically:

--- a/docs/README.de.md
+++ b/docs/README.de.md
@@ -227,13 +227,13 @@ graph TD
 ```mermaid
 graph TD
     root[pycubrid/]
-    init[__init__.py - Public API connect(), types, exceptions, __version__]
+    init["__init__.py - Public API connect(), types, exceptions, __version__"]
     connection[connection.py - Connection class connect/commit/rollback/cursor/LOB]
     cursor[cursor.py - Cursor class execute/fetch/executemany/callproc/iterator]
     types[types.py - DB-API 2.0 type objects and constructors]
     exceptions[exceptions.py - PEP 249 exception hierarchy]
     constants[constants.py - CAS function codes, data types, protocol constants]
-    protocol[protocol.py - CAS wire protocol packet classes (18 packet types)]
+    protocol["protocol.py - CAS wire protocol packet classes (18 packet types)"]
     packet[packet.py - Low-level packet reader/writer]
     lob[lob.py - LOB support]
     typed[py.typed - PEP 561 marker]
@@ -249,7 +249,7 @@ graph TD
     root --> lob
     root --> typed
     root --> aio
-    aio[aio/ - AsyncConnection, AsyncCursor, async connect()]
+    aio["aio/ - AsyncConnection, AsyncCursor, async connect()"]
 ```
 
 ## FAQ

--- a/docs/README.hi.md
+++ b/docs/README.hi.md
@@ -226,13 +226,13 @@ graph TD
 ```mermaid
 graph TD
     root[pycubrid/]
-    init[__init__.py - Public API connect(), types, exceptions, __version__]
+    init["__init__.py - Public API connect(), types, exceptions, __version__"]
     connection[connection.py - Connection class connect/commit/rollback/cursor/LOB]
     cursor[cursor.py - Cursor class execute/fetch/executemany/callproc/iterator]
     types[types.py - DB-API 2.0 type objects and constructors]
     exceptions[exceptions.py - PEP 249 exception hierarchy]
     constants[constants.py - CAS function codes, data types, protocol constants]
-    protocol[protocol.py - CAS wire protocol packet classes (18 packet types)]
+    protocol["protocol.py - CAS wire protocol packet classes (18 packet types)"]
     packet[packet.py - Low-level packet reader/writer]
     lob[lob.py - LOB support]
     typed[py.typed - PEP 561 marker]
@@ -248,7 +248,7 @@ graph TD
     root --> lob
     root --> typed
     root --> aio
-    aio[aio/ - AsyncConnection, AsyncCursor, async connect()]
+    aio["aio/ - AsyncConnection, AsyncCursor, async connect()"]
 ```
 
 ## FAQ

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -226,13 +226,13 @@ graph TD
 ```mermaid
 graph TD
     root[pycubrid/]
-    init[__init__.py - Public API connect(), types, exceptions, __version__]
+    init["__init__.py - Public API connect(), types, exceptions, __version__"]
     connection[connection.py - Connection class connect/commit/rollback/cursor/LOB]
     cursor[cursor.py - Cursor class execute/fetch/executemany/callproc/iterator]
     types[types.py - DB-API 2.0 type objects and constructors]
     exceptions[exceptions.py - PEP 249 exception hierarchy]
     constants[constants.py - CAS function codes, data types, protocol constants]
-    protocol[protocol.py - CAS wire protocol packet classes (18 packet types)]
+    protocol["protocol.py - CAS wire protocol packet classes (18 packet types)"]
     packet[packet.py - Low-level packet reader/writer]
     lob[lob.py - LOB support]
     typed[py.typed - PEP 561 marker]
@@ -248,7 +248,7 @@ graph TD
     root --> lob
     root --> typed
     root --> aio
-    aio[aio/ - AsyncConnection, AsyncCursor, async connect()]
+    aio["aio/ - AsyncConnection, AsyncCursor, async connect()"]
 ```
 
 ## FAQ

--- a/docs/README.ru.md
+++ b/docs/README.ru.md
@@ -227,13 +227,13 @@ graph TD
 ```mermaid
 graph TD
     root[pycubrid/]
-    init[__init__.py - Public API connect(), types, exceptions, __version__]
+    init["__init__.py - Public API connect(), types, exceptions, __version__"]
     connection[connection.py - Connection class connect/commit/rollback/cursor/LOB]
     cursor[cursor.py - Cursor class execute/fetch/executemany/callproc/iterator]
     types[types.py - DB-API 2.0 type objects and constructors]
     exceptions[exceptions.py - PEP 249 exception hierarchy]
     constants[constants.py - CAS function codes, data types, protocol constants]
-    protocol[protocol.py - CAS wire protocol packet classes (18 packet types)]
+    protocol["protocol.py - CAS wire protocol packet classes (18 packet types)"]
     packet[packet.py - Low-level packet reader/writer]
     lob[lob.py - LOB support]
     typed[py.typed - PEP 561 marker]
@@ -249,7 +249,7 @@ graph TD
     root --> lob
     root --> typed
     root --> aio
-    aio[aio/ - AsyncConnection, AsyncCursor, async connect()]
+    aio["aio/ - AsyncConnection, AsyncCursor, async connect()"]
 ```
 
 ## FAQ

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -225,13 +225,13 @@ graph TD
 ```mermaid
 graph TD
     root[pycubrid/]
-    init[__init__.py - Public API connect(), types, exceptions, __version__]
+    init["__init__.py - Public API connect(), types, exceptions, __version__"]
     connection[connection.py - Connection class connect/commit/rollback/cursor/LOB]
     cursor[cursor.py - Cursor class execute/fetch/executemany/callproc/iterator]
     types[types.py - DB-API 2.0 type objects and constructors]
     exceptions[exceptions.py - PEP 249 exception hierarchy]
     constants[constants.py - CAS function codes, data types, protocol constants]
-    protocol[protocol.py - CAS wire protocol packet classes (18 packet types)]
+    protocol["protocol.py - CAS wire protocol packet classes (18 packet types)"]
     packet[packet.py - Low-level packet reader/writer]
     lob[lob.py - LOB support]
     typed[py.typed - PEP 561 marker]
@@ -247,7 +247,7 @@ graph TD
     root --> lob
     root --> typed
     root --> aio
-    aio[aio/ - AsyncConnection, AsyncCursor, async connect()]
+    aio["aio/ - AsyncConnection, AsyncCursor, async connect()"]
 ```
 
 ## FAQ

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -61,7 +61,7 @@ Comprehensive solutions for common pycubrid issues — connection errors, query 
 
 ```mermaid
 flowchart TD
-    A[Start: pycubrid error observed] --> B{Connection established?}
+    A["Start: pycubrid error observed"] --> B{Connection established?}
     B -->|No| C[Check broker status and port reachability]
     C --> D{Authentication error?}
     D -->|Yes| E[Verify user/password and database]


### PR DESCRIPTION
## Summary

44 mermaid node labels across 12 Markdown files contained unquoted parentheses `()` or colons `:` that GitHub's mermaid parser interprets as syntax tokens, causing diagrams to fail rendering (showing "Loading..." forever).

## Root Cause

Mermaid treats `()` inside `[...]` labels as node-shape delimiters. When they appear unquoted, the parser misinterprets them.

```mermaid
# Broken — parser sees () as shape change
init[__init__.py - Public API connect(), types, exceptions, __version__]

# Fixed — double quotes escape the entire label
init["__init__.py - Public API connect(), types, exceptions, __version__"]
```

## Files Changed (12)
- `README.md`, `AGENTS.md`
- `docs/DEVELOPMENT.md`, `docs/PERFORMANCE.md`, `docs/PRD.md`
- `docs/PROTOCOL.md`, `docs/TROUBLESHOOTING.md`
- `docs/README.de.md`, `docs/README.hi.md`, `docs/README.ko.md`
- `docs/README.ru.md`, `docs/README.zh.md`

## Verification

Custom mermaid scanner (soon in `cubrid-lab/.github` reusable workflow) reports 0 real issues after fix (was 44).

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)
Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>