### PR TITLE
ci: add doc-lint job using reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tls: ${{ steps.filter.outputs.tls }}
+      docs: ${{ steps.filter.outputs.docs }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
@@ -26,6 +27,18 @@ jobs:
               - 'pycubrid/connection.py'
               - 'pycubrid/_connection_common.py'
               - '.github/workflows/**'
+            docs:
+              - '**/*.md'
+              - 'docs/**'
+
+  doc-lint:
+    name: Documentation lint
+    needs: detect-changes
+    if: needs.detect-changes.outputs.docs == 'true'
+    uses: cubrid-lab/.github/.github/workflows/doc-lint.yml@main
+    with:
+      exclude: "node_modules/,vendor/"
+      fail-on-issue: false  # advisory mode during initial rollout
 
   version-check:
     name: Version consistency


### PR DESCRIPTION
## Summary

Adds a documentation lint job to CI that calls the reusable workflow at `cubrid-lab/.github/.github/workflows/doc-lint.yml@main`.

## Checks
- **markdownlint-cli2** — markdown style (MD001, MD009, MD040, etc.)
- **lychee** — internal link checker (external links checked weekly)
- **scan_mermaid.py** — mermaid syntax validation

## Configuration
- Runs only when `.md` files change (via `detect-changes` path filter)
- Advisory mode: `fail-on-issue: false` (won't block PRs during initial rollout)
- After backlog is cleared, flip to enforcement mode

## Related
- Reusable workflow: cubrid-lab/.github#17 (merged)
- Mermaid fixes: #212 (merged)

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)
Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>