### PR TITLE
fix: resolve 6 code review issues (#216-221)

### DIFF
--- a/pycubrid/_connection_common.py
+++ b/pycubrid/_connection_common.py
@@ -11,14 +11,15 @@ concrete sync/async classes.
 
 from __future__ import annotations
 
-import json
+
 import logging
 import os
 import socket
 import ssl as ssl_module
 from typing import TYPE_CHECKING, Any
 
-from .exceptions import InterfaceError
+from .constants import DataSize
+from .exceptions import InterfaceError, OperationalError
 
 if TYPE_CHECKING:
     from .timing import TimingStats
@@ -88,8 +89,7 @@ class ConnectionCommonMixin:
 
         if self._json_deserializer is not None and not callable(self._json_deserializer):
             raise TypeError("json_deserializer must be callable or None")
-        if self._json_deserializer is json.loads:
-            self._json_deserializer = json.loads
+        # Note: json_deserializer is used as-is (issue #220 — removed no-op assignment).
 
         # Timing support
         self._timing: TimingStats | None = None
@@ -166,3 +166,18 @@ class ConnectionCommonMixin:
     def timing_stats(self) -> TimingStats | None:
         """Return the timing statistics object, or ``None`` if timing is disabled."""
         return self._timing
+
+    @staticmethod
+    def _validate_data_length(data_length: int) -> None:
+        """Validate the DATA_LENGTH header from the broker.
+
+        Raises OperationalError for negative or oversized values to prevent
+        ValueError on allocation or unbounded memory usage (issue #188).
+        """
+        if data_length < 0:
+            raise OperationalError(f"invalid DATA_LENGTH from broker: {data_length} (negative)")
+        if data_length > DataSize.MAX_PACKET_SIZE:
+            raise OperationalError(
+                f"invalid DATA_LENGTH from broker: {data_length} "
+                f"(exceeds max {DataSize.MAX_PACKET_SIZE})"
+            )

--- a/pycubrid/_cursor_common.py
+++ b/pycubrid/_cursor_common.py
@@ -17,6 +17,7 @@ from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Sequence
 
 from .exceptions import ProgrammingError
+from .error_codes import CAS_ERROR_TO_EXCEPTION, _DEFAULT_SQLSTATE
 
 if TYPE_CHECKING:
     from .protocol import ColumnMetaData
@@ -268,3 +269,35 @@ class CursorParamsMixin:
         columns: list[ColumnMetaData],
     ) -> tuple[DescriptionItem, ...] | None:
         return build_description(columns)
+
+
+def _raise_batch_error(err: dict[str, Any]) -> None:
+    """Raise the appropriate PEP 249 exception for a batch statement failure.
+
+    Uses CAS error code dispatch (same mapping as protocol._raise_error)
+    to select the correct exception class. Falls back to DatabaseError
+    for unknown codes.
+    """
+    code = err.get("code", -1)
+    message = err.get("message", "batch execute statement failed")
+    exc_name = CAS_ERROR_TO_EXCEPTION.get(code, "DatabaseError")
+    sqlstate = _DEFAULT_SQLSTATE.get(exc_name, "HY000")
+    # Import here to avoid circular import at module load time.
+    from .exceptions import (
+        DataError,
+        IntegrityError,
+        InternalError,
+        DatabaseError,
+        OperationalError,
+    )
+
+    exc_map = {
+        "DataError": DataError,
+        "IntegrityError": IntegrityError,
+        "InternalError": InternalError,
+        "OperationalError": OperationalError,
+        "ProgrammingError": ProgrammingError,
+        "DatabaseError": DatabaseError,
+    }
+    exc_cls = exc_map.get(exc_name, DatabaseError)
+    raise exc_cls(message, code=code, sqlstate=sqlstate)

--- a/pycubrid/aio/connection.py
+++ b/pycubrid/aio/connection.py
@@ -212,7 +212,8 @@ class AsyncConnection(ConnectionCommonMixin):
             user=self._user,
             password=self._password,
         )
-        assert self._writer is not None
+        if self._writer is None:
+            raise InterfaceError("Connection not established: writer is None")
         self._writer.write(open_db_packet.write())
         await self._writer.drain()
         data_length_bytes = await self._recv_exact(self._reader, DataSize.DATA_LENGTH)
@@ -246,9 +247,12 @@ class AsyncConnection(ConnectionCommonMixin):
         in 3.13/3.14) that this kwarg does not address.
         """
         ssl_context = self._ssl_context
-        assert ssl_context is not None
-        assert self._writer is not None
-        assert self._reader is not None
+        if ssl_context is None:
+            raise InterfaceError("SSL context not configured")
+        if self._writer is None:
+            raise InterfaceError("Connection not established: writer is None")
+        if self._reader is None:
+            raise InterfaceError("Connection not established: reader is None")
 
         loop = asyncio.get_running_loop()
         old_transport = self._writer.transport
@@ -308,7 +312,8 @@ class AsyncConnection(ConnectionCommonMixin):
         if sys.version_info[:2] != (3, 10):
             return
         ssl_context = self._ssl_context
-        assert ssl_context is not None
+        if ssl_context is None:
+            raise InterfaceError("SSL context not configured")
 
         connect_timeout = (
             float(self._connect_timeout) if self._connect_timeout is not None else None
@@ -343,7 +348,8 @@ class AsyncConnection(ConnectionCommonMixin):
         """
         sock: socket.socket | None = socket.create_connection((host, port), timeout=connect_timeout)
         try:
-            assert sock is not None
+            if sock is None:
+                raise OperationalError("Failed to create socket connection")
             sock.settimeout(handshake_timeout)
             if needs_handshake_replay:
                 # Replay the plaintext CUBRS handshake so the broker
@@ -510,7 +516,7 @@ class AsyncConnection(ConnectionCommonMixin):
         try:
             packet = await self._send_and_receive(CheckCasPacket(), allow_reconnect=False)
             return bool(packet.response_code >= 0)
-        except (InterfaceError, OperationalError, struct.error):
+        except (OSError, InterfaceError, OperationalError, struct.error):
             if not reconnect:
                 return False
             try:
@@ -622,21 +628,6 @@ class AsyncConnection(ConnectionCommonMixin):
             self._connected = False
             raise OperationalError("malformed response from broker") from exc
         return packet
-
-    @staticmethod
-    def _validate_data_length(data_length: int) -> None:
-        """Validate the DATA_LENGTH header from the broker.
-
-        Raises OperationalError for negative or oversized values to prevent
-        ValueError on allocation or unbounded memory usage (issue #188).
-        """
-        if data_length < 0:
-            raise OperationalError(f"invalid DATA_LENGTH from broker: {data_length} (negative)")
-        if data_length > DataSize.MAX_PACKET_SIZE:
-            raise OperationalError(
-                f"invalid DATA_LENGTH from broker: {data_length} "
-                f"(exceeds max {DataSize.MAX_PACKET_SIZE})"
-            )
 
     async def _recv_exact(
         self,

--- a/pycubrid/aio/cursor.py
+++ b/pycubrid/aio/cursor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import time
 from typing import Any, Sequence
 
@@ -11,10 +12,11 @@ from pycubrid._cursor_common import (
     DescriptionItem,
     DML_BATCH_VERBS,
     extract_first_keyword,
+    _raise_batch_error,
 )
 from pycubrid.constants import CUBRIDStatementType
-from pycubrid.exceptions import DatabaseError, InterfaceError, OperationalError, ProgrammingError
-from pycubrid.error_codes import CAS_ERROR_TO_EXCEPTION, _DEFAULT_SQLSTATE
+from pycubrid.exceptions import InterfaceError, OperationalError, ProgrammingError
+
 from pycubrid.protocol import (
     BatchExecutePacket,
     CloseQueryPacket,
@@ -26,29 +28,8 @@ from pycubrid.protocol import (
 
 _LOGGER = logging.getLogger(__name__)
 
-
-def _raise_batch_error(err: dict[str, Any]) -> None:
-    """Raise the appropriate PEP 249 exception for a batch statement failure."""
-    code = err.get("code", -1)
-    message = err.get("message", "batch execute statement failed")
-    exc_name = CAS_ERROR_TO_EXCEPTION.get(code, "DatabaseError")
-    sqlstate = _DEFAULT_SQLSTATE.get(exc_name, "HY000")
-    from pycubrid.exceptions import (
-        DataError,
-        IntegrityError,
-        InternalError,
-    )
-
-    exc_map = {
-        "DataError": DataError,
-        "IntegrityError": IntegrityError,
-        "InternalError": InternalError,
-        "OperationalError": OperationalError,
-        "ProgrammingError": ProgrammingError,
-        "DatabaseError": DatabaseError,
-    }
-    exc_cls = exc_map.get(exc_name, DatabaseError)
-    raise exc_cls(message, code=code, sqlstate=sqlstate)
+# Identifier validation for stored procedure names (prevents SQL injection).
+_IDENTIFIER_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_.]*$")
 
 
 class AsyncCursor(CursorParamsMixin):
@@ -315,6 +296,9 @@ class AsyncCursor(CursorParamsMixin):
         _ = (size, column)
 
     async def callproc(self, procname: str, parameters: Sequence[Any] = ()) -> Sequence[Any]:
+        """Call a stored procedure and return the original parameters."""
+        if not _IDENTIFIER_RE.match(procname):
+            raise ProgrammingError(f"Invalid stored procedure name: {procname!r}")
         placeholders = ", ".join(["?"] * len(parameters))
         if placeholders:
             sql = "CALL %s(%s)" % (procname, placeholders)

--- a/pycubrid/connection.py
+++ b/pycubrid/connection.py
@@ -493,21 +493,6 @@ class Connection(ConnectionCommonMixin):
             self._connected = False
             raise OperationalError("socket communication failed") from exc
 
-    @staticmethod
-    def _validate_data_length(data_length: int) -> None:
-        """Validate the DATA_LENGTH header from the broker.
-
-        Raises OperationalError for negative or oversized values to prevent
-        ValueError on allocation or unbounded memory usage (issue #188).
-        """
-        if data_length < 0:
-            raise OperationalError(f"invalid DATA_LENGTH from broker: {data_length} (negative)")
-        if data_length > DataSize.MAX_PACKET_SIZE:
-            raise OperationalError(
-                f"invalid DATA_LENGTH from broker: {data_length} "
-                f"(exceeds max {DataSize.MAX_PACKET_SIZE})"
-            )
-
     def _recv_exact(self, sock: socket.socket, size: int) -> bytearray:
         """Receive exactly ``size`` bytes from the socket."""
         buf = bytearray(size)

--- a/pycubrid/constants.py
+++ b/pycubrid/constants.py
@@ -421,7 +421,7 @@ class DataSize:
     DATE: int = 14
     TIME: int = 14
     DATETIME: int = 14
-    TIMESTAMP: int = 14
+    TIMESTAMP: int = 12  # year(2)+month(2)+day(2)+hour(2)+min(2)+sec(2) = 12 bytes
     RESULTSET: int = 4
     DATA_LENGTH: int = 4
     CAS_INFO: int = 4

--- a/pycubrid/cursor.py
+++ b/pycubrid/cursor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import time
 from typing import TYPE_CHECKING, Any, Sequence
 
@@ -12,10 +13,11 @@ from ._cursor_common import (
     DescriptionItem,
     DML_BATCH_VERBS,
     extract_first_keyword,
+    _raise_batch_error,
     split_on_placeholders,
 )
-from .exceptions import DatabaseError, InterfaceError, OperationalError, ProgrammingError
-from .error_codes import CAS_ERROR_TO_EXCEPTION, _DEFAULT_SQLSTATE
+from .exceptions import InterfaceError, OperationalError, ProgrammingError
+
 from .protocol import (
     BatchExecutePacket,
     CloseQueryPacket,
@@ -35,35 +37,8 @@ _split_on_placeholders = split_on_placeholders
 
 _LOGGER = logging.getLogger(__name__)
 
-
-def _raise_batch_error(err: dict[str, Any]) -> None:
-    """Raise the appropriate PEP 249 exception for a batch statement failure.
-
-    Uses CAS error code dispatch (same mapping as protocol._raise_error)
-    to select the correct exception class. Falls back to DatabaseError
-    for unknown codes.
-    """
-    code = err.get("code", -1)
-    message = err.get("message", "batch execute statement failed")
-    exc_name = CAS_ERROR_TO_EXCEPTION.get(code, "DatabaseError")
-    sqlstate = _DEFAULT_SQLSTATE.get(exc_name, "HY000")
-    # Import here to avoid circular import at module load time.
-    from .exceptions import (
-        DataError,
-        IntegrityError,
-        InternalError,
-    )
-
-    exc_map = {
-        "DataError": DataError,
-        "IntegrityError": IntegrityError,
-        "InternalError": InternalError,
-        "OperationalError": OperationalError,
-        "ProgrammingError": ProgrammingError,
-        "DatabaseError": DatabaseError,
-    }
-    exc_cls = exc_map.get(exc_name, DatabaseError)
-    raise exc_cls(message, code=code, sqlstate=sqlstate)
+# Identifier validation for stored procedure names (prevents SQL injection in callproc).
+_IDENTIFIER_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_.]*$")
 
 
 class Cursor(CursorParamsMixin):
@@ -375,6 +350,8 @@ class Cursor(CursorParamsMixin):
 
     def callproc(self, procname: str, parameters: Sequence[Any] = ()) -> Sequence[Any]:
         """Call a stored procedure and return the original parameters."""
+        if not _IDENTIFIER_RE.match(procname):
+            raise ProgrammingError(f"Invalid stored procedure name: {procname!r}")
         placeholders = ", ".join(["?"] * len(parameters))
         if placeholders:
             sql = "CALL %s(%s)" % (procname, placeholders)

--- a/pycubrid/packet.py
+++ b/pycubrid/packet.py
@@ -269,26 +269,31 @@ class PacketReader:
         return value
 
     def _parse_short(self, size: int = 0) -> int:
+        """Parse a 2-byte short. ``size`` is ignored (uniform dispatch signature)."""
         value: int = _STRUCT_SHORT.unpack_from(self._buffer, self._offset)[0]
         self._offset += DataSize.SHORT
         return value
 
     def _parse_int(self, size: int = 0) -> int:
+        """Parse a 4-byte int. ``size`` is ignored (uniform dispatch signature)."""
         value: int = _STRUCT_INT.unpack_from(self._buffer, self._offset)[0]
         self._offset += DataSize.INT
         return value
 
     def _parse_long(self, size: int = 0) -> int:
+        """Parse an 8-byte long. ``size`` is ignored (uniform dispatch signature)."""
         value: int = _STRUCT_LONG.unpack_from(self._buffer, self._offset)[0]
         self._offset += DataSize.LONG
         return value
 
     def _parse_float(self, size: int = 0) -> float:
+        """Parse a 4-byte float. ``size`` is ignored (uniform dispatch signature)."""
         value: float = _STRUCT_FLOAT.unpack_from(self._buffer, self._offset)[0]
         self._offset += DataSize.FLOAT
         return value
 
     def _parse_double(self, size: int = 0) -> float:
+        """Parse an 8-byte double. ``size`` is ignored (uniform dispatch signature)."""
         value: float = _STRUCT_DOUBLE.unpack_from(self._buffer, self._offset)[0]
         self._offset += DataSize.DOUBLE
         return value

--- a/pycubrid/protocol.py
+++ b/pycubrid/protocol.py
@@ -583,8 +583,8 @@ def _convert_collection_value(column_type: int, value: Any) -> Any:
         except TypeError:
             # Unhashable elements (e.g. dicts from JSON) — return as tuple.
             return tuple(value)
-    if column_type in (CUBRIDDataType.MULTISET, CUBRIDDataType.SEQUENCE):
-        return value
+    # MULTISET and SEQUENCE are returned as-is (already list).
+    # No other collection types need post-processing.
     return value
 
 
@@ -716,7 +716,11 @@ class OpenDatabasePacket:
         self.session_id: int = 0
 
     def write(self) -> bytes:
-        """Serialize the open database packet (628 bytes, no header)."""
+        """Serialize the open database packet.
+
+        Wire format: database(32) + user(32) + password(32) + extended_info(512)
+        + reserved(20) = 628 bytes (no header).
+        """
         writer = PacketWriter(reserve_header=False)
         writer._write_fixed_length_string(self.database, 32)
         writer._write_fixed_length_string(self.user, 32)


### PR DESCRIPTION
## Summary

Line-by-line code review identified 6 issues. This PR resolves all of them:

| Issue | Severity | Fix |
|-------|----------|-----|
| #216 | P0/security | Validate procname in callproc() with identifier regex to prevent SQL injection |
| #217 | P1/bug | Add OSError to async ping() exception handler (sync version already had it) |
| #218 | P1/bug | Fix DataSize.TIMESTAMP from 14 to 12 to match actual wire format |
| #219 | P2/robustness | Replace assert statements with explicit InterfaceError checks |
| #220 | P2/cleanup | Remove dead code, no-op assignment, document magic numbers and unused params |
| #221 | P2/refactor | Move _raise_batch_error to _cursor_common, _validate_data_length to _connection_common |

## Test Plan

- 955 tests passed, 99 skipped