### PR TITLE
fix: write-path struct.error parity, AsyncConnection autocommit kwarg, Decimal NaN/Inf guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+- **Write-path serialization overflow now raises `DataError`, not raw `struct.error` (#223)** — `_send_and_receive` (sync) and `_do_send_and_receive` (async) called `packet.write(self._cas_info)` inside a block that only caught `OSError`. An oversized outbound value (e.g. a huge LOB offset/length, or a large `executemany` batch) trips `struct.pack`'s int32 range check and raised a bare `struct.error`, escaping the PEP 249 contract entirely — the write-side counterpart of the parse-side hardening already done in #201/#205. Both `packet.write()` call sites now catch `struct.error` and raise `DataError("parameter value too large to serialize into CAS request")`; since nothing was sent to the socket yet, the connection is left open and usable rather than torn down.
+- **`AsyncConnection(autocommit=True)` no longer silently dropped (#224)** — constructing `AsyncConnection` directly (bypassing the `pycubrid.aio.connect()` factory) with `autocommit=True` swallowed the flag into `**kwargs` with no error and no effect, unlike sync `Connection`, which has always accepted `autocommit` in its own constructor. `AsyncConnection.__init__` now accepts a keyword-only `autocommit: bool = False` parameter, applied via `await self.set_autocommit(True)` the first time `connect()` completes. The `pycubrid.aio.connect()` factory no longer needs its own separate `set_autocommit()` call — `autocommit` just flows straight through to the constructor now.
+- **`Decimal('NaN')`/`Decimal('Infinity')` now rejected like their `float` equivalents (#225)** — `format_parameter()`'s `Decimal` branch returned `str(value)` unconditionally, before ever reaching the NaN/Inf guard that already protects the `int`/`float` branch below it. A `Decimal('NaN')` or `Decimal('Infinity')` parameter was silently formatted as the bare token `NaN`/`Infinity` and sent straight to the server instead of raising the documented `ProgrammingError("nan and inf are not supported by CUBRID")`. The `Decimal` branch now checks `value.is_nan() or value.is_infinite()` first.
+
 ## [1.6.1] - 2026-07-18
 
 ### Fixed

--- a/api-baseline.json
+++ b/api-baseline.json
@@ -1169,6 +1169,11 @@
                   "name": "fetch_size"
                 },
                 {
+                  "has_default": true,
+                  "kind": "KEYWORD_ONLY",
+                  "name": "autocommit"
+                },
+                {
                   "has_default": false,
                   "kind": "VAR_KEYWORD",
                   "name": "kwargs"
@@ -1460,6 +1465,11 @@
               "has_default": true,
               "kind": "POSITIONAL_OR_KEYWORD",
               "name": "fetch_size"
+            },
+            {
+              "has_default": true,
+              "kind": "KEYWORD_ONLY",
+              "name": "autocommit"
             },
             {
               "has_default": false,

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -165,7 +165,7 @@ Create and open an async connection.
 
 - Returns a connected `AsyncConnection`.
 - Accepts the same collection / JSON decoding kwargs as `pycubrid.connect()`.
-- Supports `autocommit=True` via `await conn.set_autocommit(True)` during construction.
+- Supports `autocommit=True`, applied automatically once the connection is established. `AsyncConnection` itself now accepts `autocommit` directly too (as a keyword-only constructor argument), so constructing it without going through this factory no longer silently drops the flag.
 - Provides a similar async surface to the sync API, including `await conn.ping(reconnect=...)`; `create_lob()` remains sync-only, and auto-commit changes go through `await conn.set_autocommit(...)` instead of a property setter.
 - Accepts the same `ssl` parameter as `pycubrid.connect()`: `True`, `False`/`None`, or a custom `SSLContext`; when `True`, the default verified context enforces a TLS 1.2 minimum. Async TLS uses CUBRID's STARTTLS-style upgrade — the `CUBRS` handshake is sent in plaintext, then the transport is upgraded via `asyncio.AbstractEventLoop.start_tls()` (bounded by `ssl_handshake_timeout`) before `OPEN_DATABASE`. See the [Connection guide](CONNECTION.md#ssltls) for full details and the Python 3.10 `start_tls()` cert-verify caveat ([#156](https://github.com/cubrid-lab/pycubrid/issues/156)).
 
@@ -876,6 +876,11 @@ Async counterpart to `Connection` for use with `asyncio`, with a similar surface
 `AsyncConnection` exposes async `ping()` parity with sync `Connection.ping()`. `create_lob()` remains sync-only.
 Concurrent awaiters on the same `AsyncConnection` are serialized with a per-connection
 `asyncio.Lock`, so shared use is safe but requests still execute one at a time.
+
+`AsyncConnection.__init__` accepts a keyword-only `autocommit: bool = False` argument, applied
+automatically the first time `await conn.connect()` completes — the same effect as
+`await conn.set_autocommit(True)`, but usable when constructing `AsyncConnection` directly
+instead of through the `pycubrid.aio.connect()` factory.
 
 ```python
 async with await pycubrid.aio.connect(database="testdb") as conn:

--- a/pycubrid/_cursor_common.py
+++ b/pycubrid/_cursor_common.py
@@ -174,6 +174,8 @@ def format_parameter(value: Any, *, no_backslash_escapes: bool = False) -> str:
     if isinstance(value, datetime.time):
         return "TIME'%s'" % value.strftime("%H:%M:%S")
     if isinstance(value, Decimal):
+        if value.is_nan() or value.is_infinite():
+            raise ProgrammingError("nan and inf are not supported by CUBRID")
         return str(value)
     if isinstance(value, (int, float)):
         if math.isnan(value) or math.isinf(value):

--- a/pycubrid/aio/__init__.py
+++ b/pycubrid/aio/__init__.py
@@ -33,7 +33,6 @@ async def connect(
     Returns:
         A connected :class:`AsyncConnection` instance.
     """
-    autocommit = kwargs.pop("autocommit", False)
     connection_kwargs: dict[str, Any] = {
         "host": host,
         "port": port,
@@ -49,8 +48,6 @@ async def connect(
 
     conn = AsyncConnection(**connection_kwargs)
     await conn.connect()
-    if autocommit:
-        await conn.set_autocommit(True)
     return conn
 
 

--- a/pycubrid/aio/connection.py
+++ b/pycubrid/aio/connection.py
@@ -13,7 +13,7 @@ from typing import Any
 
 from pycubrid._connection_common import ConnectionCommonMixin, resolve_ssl_context
 from pycubrid.constants import CCIDbParam, DataSize
-from pycubrid.exceptions import InterfaceError, OperationalError
+from pycubrid.exceptions import DataError, InterfaceError, OperationalError
 from pycubrid.protocol import (
     CheckCasPacket,
     ClientInfoExchangePacket,
@@ -70,6 +70,8 @@ class AsyncConnection(ConnectionCommonMixin):
         password: str,
         ssl: bool | ssl_module.SSLContext | None = None,
         fetch_size: int = 100,
+        *,
+        autocommit: bool = False,
         **kwargs: Any,
     ) -> None:
         self._ssl_context = resolve_ssl_context(ssl)
@@ -90,6 +92,9 @@ class AsyncConnection(ConnectionCommonMixin):
         self._reader: asyncio.StreamReader | None = None
         self._writer: asyncio.StreamWriter | None = None
         self._lock = asyncio.Lock()
+        # Applied in connect() (can't await a live SET_DB_PARAMETER round-trip
+        # here — __init__ isn't a coroutine). See connect() below.
+        self._pending_autocommit = autocommit
 
     async def connect(self) -> None:
         """Establish a TCP CAS session with broker handshake and open database.
@@ -105,8 +110,14 @@ class AsyncConnection(ConnectionCommonMixin):
 
         .. _#156: https://github.com/cubrid-lab/pycubrid/issues/156
         """
+        was_connected = self._connected
         async with self._lock:
             await self._connect_locked()
+        # set_autocommit() takes self._lock itself, so it must run after the
+        # lock above is released — and only on the connecting edge, so a
+        # later no-op connect() (already connected) can't re-send it.
+        if not was_connected and self._pending_autocommit:
+            await self.set_autocommit(True)
 
     async def _connect_locked(self) -> None:
         if self._connected:
@@ -611,7 +622,10 @@ class AsyncConnection(ConnectionCommonMixin):
         reader = self._reader
         if writer is None or reader is None:
             raise InterfaceError("connection is closed")
-        request_data = packet.write(self._cas_info)
+        try:
+            request_data = packet.write(self._cas_info)
+        except struct.error as exc:
+            raise DataError("parameter value too large to serialize into CAS request") from exc
         writer.write(request_data)
         await writer.drain()
 

--- a/pycubrid/aio/connection.py
+++ b/pycubrid/aio/connection.py
@@ -110,14 +110,16 @@ class AsyncConnection(ConnectionCommonMixin):
 
         .. _#156: https://github.com/cubrid-lab/pycubrid/issues/156
         """
-        was_connected = self._connected
         async with self._lock:
+            # Read the connecting edge *inside* the lock so two concurrent
+            # connect() calls can't both see "not connected" and both apply
+            # autocommit (PR #226 review). Apply it in the same lock hold via
+            # _send_and_receive_locked so no query on another task can slip
+            # between the handshake and the SET_DB_PARAMETER round-trip.
+            did_connect = not self._connected
             await self._connect_locked()
-        # set_autocommit() takes self._lock itself, so it must run after the
-        # lock above is released — and only on the connecting edge, so a
-        # later no-op connect() (already connected) can't re-send it.
-        if not was_connected and self._pending_autocommit:
-            await self.set_autocommit(True)
+            if did_connect and self._pending_autocommit:
+                await self._apply_pending_autocommit_locked()
 
     async def _connect_locked(self) -> None:
         if self._connected:
@@ -154,6 +156,44 @@ class AsyncConnection(ConnectionCommonMixin):
                 await self._close_streams()
             if _timing is not None:
                 _timing.record_connect(time.perf_counter_ns() - _start)
+
+    async def _apply_pending_autocommit_locked(self) -> None:
+        """Apply the constructor's ``autocommit=True`` the first time
+        ``connect()`` succeeds.  Must be called while ``self._lock`` is held,
+        in the same hold that performed the connect.  Uses
+        ``_send_and_receive_locked`` directly (like
+        ``_restore_session_state_locked``) rather than the public
+        ``set_autocommit`` — the latter would re-acquire ``self._lock`` and
+        deadlock, and releasing the lock first would let a query on another
+        task interleave before the SET_DB_PARAMETER round-trip completes
+        (torn autocommit state).
+
+        This bootstraps the explicit-autocommit state (``_autocommit`` +
+        ``_autocommit_explicitly_set``), after which the normal reconnect
+        restore machinery (``_restore_session_state_locked``) takes over — so
+        it is intentionally driven only from the public ``connect()`` path,
+        not the internal ``ping``/reconnect path, to avoid re-emitting on top
+        of restore.
+
+        ``self._pending_autocommit`` is cleared only on success, so a
+        transient failure leaves it set for the next ``connect()`` attempt to
+        retry, and — once cleared — a later reconnect will never re-apply the
+        constructor's original intent over an explicit ``set_autocommit(False)``
+        the caller made in between.
+        """
+        try:
+            await self._send_and_receive_locked(
+                SetDbParameterPacket(parameter=CCIDbParam.AUTO_COMMIT, value=1),
+                allow_reconnect=False,
+            )
+            await self._send_and_receive_locked(CommitPacket(), allow_reconnect=False)
+        except Exception as exc:
+            await self._close_streams()
+            self._connected = False
+            raise OperationalError("failed to apply autocommit after connect") from exc
+        self._autocommit = True
+        self._autocommit_explicitly_set = True
+        self._pending_autocommit = False
 
     async def _do_connect_handshake(
         self,

--- a/pycubrid/connection.py
+++ b/pycubrid/connection.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 from ._connection_common import ConnectionCommonMixin, resolve_ssl_context
 from .constants import CCIDbParam, DataSize
-from .exceptions import InterfaceError, OperationalError
+from .exceptions import DataError, InterfaceError, OperationalError
 from .protocol import (
     CheckCasPacket,
     ClientInfoExchangePacket,
@@ -466,7 +466,10 @@ class Connection(ConnectionCommonMixin):
             raise InterfaceError("connection is closed")
 
         try:
-            request_data = packet.write(self._cas_info)
+            try:
+                request_data = packet.write(self._cas_info)
+            except struct.error as exc:
+                raise DataError("parameter value too large to serialize into CAS request") from exc
             self._socket.sendall(request_data)
             if _LOGGER.isEnabledFor(logging.DEBUG):
                 _LOGGER.debug("send: %d bytes", len(request_data))

--- a/tests/test_aio_cursor_parity.py
+++ b/tests/test_aio_cursor_parity.py
@@ -60,6 +60,9 @@ async def test_async_connect_threads_decode_collection_and_json_kwargs() -> None
         )
 
     assert result is mock_connection
+    # autocommit now flows straight through to AsyncConnection's own
+    # constructor (applied inside connect()) instead of the factory calling
+    # set_autocommit() separately — see AsyncConnection.__init__/connect().
     connection_class.assert_called_once_with(
         host="localhost",
         port=33000,
@@ -68,9 +71,9 @@ async def test_async_connect_threads_decode_collection_and_json_kwargs() -> None
         password="",
         decode_collections=True,
         json_deserializer=json.loads,
+        autocommit=True,
     )
     mock_connection.connect.assert_awaited_once_with()
-    mock_connection.set_autocommit.assert_awaited_once_with(True)
 
 
 @pytest.mark.asyncio

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -908,15 +908,28 @@ class TestAsyncConnectModule:
 
     @pytest.mark.asyncio
     async def test_connect_module_function_with_autocommit(self) -> None:
+        """``autocommit`` now flows straight into AsyncConnection's own
+        constructor (which applies it inside connect()) instead of the
+        factory calling set_autocommit() separately afterwards — so a user
+        constructing AsyncConnection directly gets the same behavior."""
         import pycubrid.aio as aio_mod
 
         with patch.object(aio_mod, "AsyncConnection") as mock_cls:
             instance = MagicMock()
             instance.connect = AsyncMock()
-            instance.set_autocommit = AsyncMock()
             mock_cls.return_value = instance
             await aio_mod.connect(autocommit=True)
-            instance.set_autocommit.assert_awaited_with(True)
+            mock_cls.assert_called_once_with(
+                host="localhost",
+                port=33000,
+                database="",
+                user="dba",
+                password="",
+                decode_collections=False,
+                json_deserializer=None,
+                autocommit=True,
+            )
+            instance.connect.assert_awaited()
 
 
 class TestAsyncConnectSocketLeak:

--- a/tests/test_network_edge_cases.py
+++ b/tests/test_network_edge_cases.py
@@ -10,7 +10,7 @@ import pytest
 from pycubrid.aio.connection import AsyncConnection
 from pycubrid.connection import Connection
 from pycubrid.constants import DataSize
-from pycubrid.exceptions import OperationalError
+from pycubrid.exceptions import DataError, OperationalError
 from pycubrid.protocol import CommitPacket
 
 
@@ -223,6 +223,49 @@ class TestDataLengthValidation:
         """Async connection must reject oversized DATA_LENGTH (#188)."""
         with pytest.raises(OperationalError, match="exceeds max"):
             AsyncConnection._validate_data_length(DataSize.MAX_PACKET_SIZE + 1)
+
+
+class TestWritePathSerializationErrors:
+    """packet.write() overflow must surface as DataError, not a raw struct.error.
+
+    Mirrors the existing parse-side hardening (malformed broker response ->
+    OperationalError, #187/#201): an oversized outbound value (e.g. a huge
+    LOB write or executemany batch) blows up struct.pack's int32 range check
+    before anything is sent, so it must not leak past the PEP 249 exception
+    contract, and — unlike a parse failure — the socket is still perfectly
+    usable since nothing went over the wire yet.
+    """
+
+    def test_sync_write_overflow_raises_data_error(self) -> None:
+        conn, sock = make_connected_connection()
+        sock.sendall.reset_mock()  # clear the handshake's own sendall() calls
+        packet = MagicMock()
+        packet.write.side_effect = struct.error(
+            "'i' format requires -2147483648 <= number <= 2147483647"
+        )
+
+        with pytest.raises(DataError, match="too large"):
+            conn._send_and_receive(packet)
+
+        assert sock.sendall.called is False
+        assert conn._connected is True
+
+    @pytest.mark.asyncio
+    async def test_async_write_overflow_raises_data_error(self) -> None:
+        conn = AsyncConnection("localhost", 33000, "testdb", "dba", "")
+        conn._connected = True
+        conn._cas_info = b"\x01\x01\x02\x03"
+        conn._reader, conn._writer, _ = make_mock_stream_pair()
+        packet = MagicMock()
+        packet.write.side_effect = struct.error(
+            "'i' format requires -2147483648 <= number <= 2147483647"
+        )
+
+        with pytest.raises(DataError, match="too large"):
+            await conn._send_and_receive(packet)
+
+        assert conn._writer.write.called is False
+        assert conn._connected is True
 
 
 class TestAsyncConnectionNetworkEdgeCases:
@@ -777,6 +820,39 @@ class TestAsyncPositiveRestoreOnReconnect:
 
         assert result is True
         assert restore_order == ["connect", "restore"]
+
+    @pytest.mark.asyncio
+    async def test_async_connection_constructor_autocommit_is_applied_on_connect(self) -> None:
+        """Regression: constructing AsyncConnection(..., autocommit=True)
+        directly (bypassing the pycubrid.aio.connect() factory) used to
+        silently drop the flag — **kwargs swallowed it with no error and no
+        effect. connect() must now apply it itself."""
+        conn = AsyncConnection("localhost", 33000, "testdb", "dba", "", autocommit=True)
+
+        async def fake_connect_locked() -> None:
+            conn._connected = True
+
+        conn._connect_locked = fake_connect_locked  # type: ignore[method-assign]
+        conn.set_autocommit = AsyncMock()  # type: ignore[method-assign]
+
+        await conn.connect()
+
+        conn.set_autocommit.assert_awaited_once_with(True)
+
+    @pytest.mark.asyncio
+    async def test_async_connection_constructor_autocommit_not_reapplied_on_second_connect(
+        self,
+    ) -> None:
+        """A second (no-op) connect() call on an already-connected instance
+        must not re-send SET_DB_PARAMETER."""
+        conn = AsyncConnection("localhost", 33000, "testdb", "dba", "", autocommit=True)
+        conn._connected = True  # already connected
+        conn._connect_locked = AsyncMock()  # type: ignore[method-assign]
+        conn.set_autocommit = AsyncMock()  # type: ignore[method-assign]
+
+        await conn.connect()
+
+        conn.set_autocommit.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_async_check_reconnect_invokes_restore_when_explicit(self) -> None:

--- a/tests/test_network_edge_cases.py
+++ b/tests/test_network_edge_cases.py
@@ -826,18 +826,34 @@ class TestAsyncPositiveRestoreOnReconnect:
         """Regression: constructing AsyncConnection(..., autocommit=True)
         directly (bypassing the pycubrid.aio.connect() factory) used to
         silently drop the flag — **kwargs swallowed it with no error and no
-        effect. connect() must now apply it itself."""
+        effect. connect() must now apply it itself, atomically under the
+        connect lock (PR #226 review: not via the public set_autocommit(),
+        which would release-then-reacquire the lock)."""
+        from pycubrid.protocol import CommitPacket, SetDbParameterPacket
+
         conn = AsyncConnection("localhost", 33000, "testdb", "dba", "", autocommit=True)
+        sends: list[object] = []
 
         async def fake_connect_locked() -> None:
             conn._connected = True
 
+        async def fake_send_locked(packet: object, *, allow_reconnect: bool = True) -> object:
+            del allow_reconnect
+            sends.append(packet)
+            return MagicMock()
+
         conn._connect_locked = fake_connect_locked  # type: ignore[method-assign]
-        conn.set_autocommit = AsyncMock()  # type: ignore[method-assign]
+        conn._send_and_receive_locked = fake_send_locked  # type: ignore[method-assign]
 
         await conn.connect()
 
-        conn.set_autocommit.assert_awaited_once_with(True)
+        assert len(sends) == 2
+        assert isinstance(sends[0], SetDbParameterPacket)
+        assert sends[0].value == 1
+        assert isinstance(sends[1], CommitPacket)
+        assert conn._autocommit is True
+        assert conn._autocommit_explicitly_set is True
+        assert conn._pending_autocommit is False
 
     @pytest.mark.asyncio
     async def test_async_connection_constructor_autocommit_not_reapplied_on_second_connect(
@@ -846,13 +862,110 @@ class TestAsyncPositiveRestoreOnReconnect:
         """A second (no-op) connect() call on an already-connected instance
         must not re-send SET_DB_PARAMETER."""
         conn = AsyncConnection("localhost", 33000, "testdb", "dba", "", autocommit=True)
-        conn._connected = True  # already connected
-        conn._connect_locked = AsyncMock()  # type: ignore[method-assign]
-        conn.set_autocommit = AsyncMock()  # type: ignore[method-assign]
+        sends: list[object] = []
+
+        async def fake_connect_locked() -> None:
+            conn._connected = True
+
+        async def fake_send_locked(packet: object, *, allow_reconnect: bool = True) -> object:
+            del allow_reconnect
+            sends.append(packet)
+            return MagicMock()
+
+        conn._connect_locked = fake_connect_locked  # type: ignore[method-assign]
+        conn._send_and_receive_locked = fake_send_locked  # type: ignore[method-assign]
+
+        await conn.connect()
+        assert len(sends) == 2
+
+        await conn.connect()  # already connected: must be a pure no-op
+
+        assert len(sends) == 2
+
+    @pytest.mark.asyncio
+    async def test_async_connection_concurrent_connect_applies_autocommit_once(self) -> None:
+        """Regression for PR #226 review (yeongseon + Copilot): computing
+        ``was_connected`` before acquiring the lock let two concurrent
+        connect() calls both observe 'not yet connected' and both send
+        SET_DB_PARAMETER. i_connected is now read and consumed entirely
+        inside one lock hold, so only the caller that actually performs the
+        connect applies autocommit."""
+        conn = AsyncConnection("localhost", 33000, "testdb", "dba", "", autocommit=True)
+        sends: list[object] = []
+
+        async def fake_connect_locked() -> None:
+            await asyncio.sleep(0)  # give a concurrent connect() a chance to interleave
+            conn._connected = True
+
+        async def fake_send_locked(packet: object, *, allow_reconnect: bool = True) -> object:
+            del allow_reconnect
+            sends.append(packet)
+            await asyncio.sleep(0)
+            return MagicMock()
+
+        conn._connect_locked = fake_connect_locked  # type: ignore[method-assign]
+        conn._send_and_receive_locked = fake_send_locked  # type: ignore[method-assign]
+
+        await asyncio.gather(conn.connect(), conn.connect())
+
+        from pycubrid.protocol import SetDbParameterPacket
+
+        set_param_sends = [p for p in sends if isinstance(p, SetDbParameterPacket)]
+        assert len(set_param_sends) == 1
+
+    @pytest.mark.asyncio
+    async def test_async_apply_pending_autocommit_failure_leaves_pending_for_retry(self) -> None:
+        """A transient failure while applying the constructor's autocommit
+        must not silently drop the user's intent — _pending_autocommit stays
+        set so the next connect() attempt retries it."""
+        conn = AsyncConnection("localhost", 33000, "testdb", "dba", "", autocommit=True)
+
+        async def fake_connect_locked() -> None:
+            conn._connected = True
+
+        conn._connect_locked = fake_connect_locked  # type: ignore[method-assign]
+        conn._send_and_receive_locked = AsyncMock(  # type: ignore[method-assign]
+            side_effect=OperationalError("broker rejected SET")
+        )
+        conn._close_streams = AsyncMock()  # type: ignore[method-assign]
+
+        with pytest.raises(OperationalError, match="failed to apply autocommit"):
+            await conn.connect()
+
+        assert conn._pending_autocommit is True
+        assert conn._connected is False
+
+    @pytest.mark.asyncio
+    async def test_async_reconnect_does_not_override_explicit_autocommit_false(self) -> None:
+        """Regression (Copilot review on PR #226): once the constructor's
+        pending autocommit has been applied and cleared, a later reconnect
+        must not resurrect it over an explicit set_autocommit(False) made in
+        between."""
+        conn = AsyncConnection("localhost", 33000, "testdb", "dba", "", autocommit=True)
+        sends: list[object] = []
+
+        async def fake_connect_locked() -> None:
+            conn._connected = True
+
+        async def fake_send_locked(packet: object, *, allow_reconnect: bool = True) -> object:
+            del allow_reconnect
+            sends.append(packet)
+            return MagicMock()
+
+        conn._connect_locked = fake_connect_locked  # type: ignore[method-assign]
+        conn._send_and_receive_locked = fake_send_locked  # type: ignore[method-assign]
+
+        await conn.connect()
+        assert conn._autocommit is True
+
+        conn._autocommit = False  # e.g. via an explicit await conn.set_autocommit(False)
+        sends.clear()
+        conn._connected = False  # simulate close() + reconnect
 
         await conn.connect()
 
-        conn.set_autocommit.assert_not_awaited()
+        assert sends == []
+        assert conn._autocommit is False
 
     @pytest.mark.asyncio
     async def test_async_check_reconnect_invokes_restore_when_explicit(self) -> None:

--- a/tests/test_param_security.py
+++ b/tests/test_param_security.py
@@ -141,6 +141,18 @@ class TestFormatParameterTypes:
         with pytest.raises(ProgrammingError, match="nan and inf"):
             cursor._format_parameter(float("-inf"))
 
+    def test_decimal_nan_raises(self, cursor: object) -> None:
+        with pytest.raises(ProgrammingError, match="nan and inf"):
+            cursor._format_parameter(Decimal("NaN"))
+
+    def test_decimal_inf_raises(self, cursor: object) -> None:
+        with pytest.raises(ProgrammingError, match="nan and inf"):
+            cursor._format_parameter(Decimal("Infinity"))
+
+    def test_decimal_neg_inf_raises(self, cursor: object) -> None:
+        with pytest.raises(ProgrammingError, match="nan and inf"):
+            cursor._format_parameter(Decimal("-Infinity"))
+
     def test_bytearray_hex(self, cursor: object) -> None:
         assert cursor._format_parameter(bytearray(b"\xca\xfe")) == "X'cafe'"
 


### PR DESCRIPTION
## Summary

Three independently-reproduced gaps found while auditing the current driver state, filed as issues #223/#224/#225 and fixed together here since they're all small, focused input/exception-handling hygiene fixes.

### #223 — write-path serialization overflow escapes the PEP 249 contract

`_send_and_receive` (sync) and `_do_send_and_receive` (async) call `packet.write(self._cas_info)` inside a block that only catches `OSError`. An oversized outbound value (huge LOB offset/length, large `executemany` batch) trips `struct.pack`'s int32 range check and raises a bare `struct.error` — this is the write-side counterpart of the parse-side hardening already done in #201/#205, which never got mirrored on the write side.

```python
>>> LOBReadPacket(b'handle', 0, 5_000_000_000).write(b'\x00\x00\x00\x00')
struct.error: 'i' format requires -2147483648 <= number <= 2147483647
```

Fix: catch `struct.error` around both `packet.write()` call sites, raise `DataError("parameter value too large to serialize into CAS request")`. Since nothing was sent to the socket yet, the connection is left open rather than torn down (unlike the parse-error case, which genuinely desyncs the transport).

### #224 — `AsyncConnection(autocommit=True)` silently dropped outside the factory

`AsyncConnection.__init__` never had an `autocommit` parameter — `pycubrid.aio.connect()` worked around this by popping it out of `kwargs` and calling `await conn.set_autocommit(True)` separately after connecting. But `AsyncConnection` is directly exported in `pycubrid.aio.__all__`; constructing it directly with `autocommit=True` got swallowed into `**kwargs` with no error and no effect.

Fix: `AsyncConnection.__init__` now accepts a keyword-only `autocommit: bool = False`, stored and applied via `await self.set_autocommit(True)` the first time `connect()` completes (after releasing `self._lock`, since `set_autocommit()` acquires it itself — verified this doesn't deadlock). The factory no longer needs its own separate call; `autocommit` flows straight through. This is a purely additive constructor parameter (keyword-only, defaulted, at the end of the list) — permitted in a minor release per `RELEASE_POLICY.md` §2. `api-baseline.json` regenerated accordingly.

### #225 — `Decimal('NaN')`/`Decimal('Infinity')` bypass the NaN/Inf guard

`format_parameter()`'s `Decimal` branch returns `str(value)` unconditionally, before ever reaching the NaN/Inf guard on the `int`/`float` branch below it:

```python
>>> format_parameter(Decimal('NaN'))
'NaN'  # sent straight into the SQL text, unquoted
>>> format_parameter(float('nan'))
ProgrammingError: nan and inf are not supported by CUBRID  # the existing, correct behavior
```

Fix: check `value.is_nan() or value.is_infinite()` (the native `Decimal` methods) before the early return.

## Test plan

- [x] New regression tests for all three (sync + async where applicable): `tests/test_network_edge_cases.py::TestWritePathSerializationErrors`, `TestSessionStateRestoreOnReconnect::test_async_connection_constructor_autocommit_*`, `tests/test_param_security.py::test_decimal_{nan,inf,neg_inf}_raises`
- [x] Updated two pre-existing tests whose expectations described the old `set_autocommit()`-after-the-fact factory behavior (`test_aio_cursor_parity.py`, `test_async.py`)
- [x] `make test`: 946 passed, 58 skipped, coverage 96.48% (gate 95%)
- [x] `make check` (ruff + mypy): clean
- [x] `bandit`: no issues
- [x] `python scripts/check_public_api.py --update` run, `api-baseline.json` diff reviewed (10 lines, exactly the new `autocommit` param)
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] `docs/API_REFERENCE.md` updated (autocommit now native on `AsyncConnection`, not just the factory)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Chore

## Related Issues

Fixes #223, #224, #225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)