### PR TITLE
ci: migrate CodeQL to org-level reusable workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,18 +15,6 @@ permissions:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
-        with:
-          languages: python
-          queries: security-extended
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
-        with:
-          category: "/language:python"
+    uses: cubrid-lab/.github/.github/workflows/codeql.yml@main
+    with:
+      language: python


### PR DESCRIPTION
## Summary

Replace the inline CodeQL workflow (32 lines) with a 21-line call to the org-level reusable workflow at `cubrid-lab/.github/.github/workflows/codeql.yml@main`.

**Before**: Each repo had its own full CodeQL config with pinned action SHAs to maintain.
**After**: One org-level workflow, each repo just calls it with `language: python`.

Refs cubrid-lab/.github#11