### PR TITLE
ci: notify cookbook smoke tests on release

### DIFF
--- a/.github/workflows/notify-cookbook.yml
+++ b/.github/workflows/notify-cookbook.yml
@@ -1,0 +1,22 @@
+name: Notify Cookbook
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch smoke test to cookbook
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.COOKBOOK_DISPATCH_TOKEN }}
+          repository: cubrid-lab/cubrid-cookbook-python
+          event-type: upstream-released
+          client-payload: |
+            {"package": "pycubrid", "ref": "${{ github.ref_name }}"}


### PR DESCRIPTION
## Summary
Adds `notify-cookbook.yml`: on a release (tag `v*` push), fires a `repository_dispatch` (`upstream-released`) into `cubrid-lab/cubrid-cookbook-python`, so the cookbook smoke tests run immediately against this new release.

## Requires
A repository secret **`COOKBOOK_DISPATCH_TOKEN`** — a token with `contents:write` (or `actions:write`) on `cubrid-lab/cubrid-cookbook-python`. The default `GITHUB_TOKEN` cannot dispatch across repositories.

Until the secret is added, the cookbook's daily cron still covers new releases within 24h.