### PR TITLE
build: pin ruff's lint rule selection so version bumps stop breaking CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+- **Ruff lint rule selection now declared explicitly (#247)** — `pyproject.toml` configured ruff but never set `[tool.ruff.lint] select`, so `ruff check` inherited ruff's implicit defaults. Ruff expanded that default set in 0.16 (59 → 413 rules against this repo's config), which is why #245 (`0.15.22 → 0.16.1`) failed lint with 237 errors in untouched code. Pinning the ruff *version* in #236 stopped unpinned installs from drifting, but could not survive the bump itself — the rule set is now pinned too, via `select = ["E4", "E7", "E9", "F"]`, which is exactly what ruff selected by default through 0.15.x (same 59 rules under both versions).
+
 ## [1.6.2] - 2026-08-06
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,14 @@ version = {attr = "pycubrid.__version__"}
 line-length = 100
 target-version = "py310"
 
+[tool.ruff.lint]
+# Pin the rule set explicitly instead of inheriting ruff's implicit defaults.
+# Ruff expanded its default selection in 0.16 (59 -> 413 rules against this
+# config), which turns every routine ruff bump into a CI-breaking change
+# unrelated to our own code. These four groups are exactly what ruff selected
+# by default through 0.15.x.
+select = ["E4", "E7", "E9", "F"]
+
 [tool.ruff.lint.isort]
 known-first-party = ["pycubrid"]
 


### PR DESCRIPTION
Unblocks #245 and every future ruff bump.

## What was wrong

`pyproject.toml` configured ruff but never declared a rule selection, so `ruff check` ran whatever ruff picks by default. Ruff changed that default in 0.16. Counting enabled rules against this repo's own config:

```
$ ruff@0.15.22 check --show-settings pyproject.toml   ->  59 rules  ->  All checks passed!
$ ruff@0.16.1  check --show-settings pyproject.toml   -> 413 rules  ->  Found 237 errors
```

That is why #245 (`ruff 0.15.22 → 0.16.1`) fails `lint` — and with it `CI Gate` — on 237 errors in code the PR never touches.

## Why the version pin in #236 was not enough

#236 fixed the lint job installing ruff unpinned, so a fresh `pip install ruff` could no longer drift to whatever shipped that morning. That was the right fix for that problem, and it is why `main` is green today.

But a version pin only holds until the pin itself moves. The moment dependabot proposes `0.15.22 → 0.16.1`, the implicit default rule set moves with it and the build breaks again — which is exactly what #245 is. Pinning the *rule set* is the missing half.

## What this PR does

```toml
[tool.ruff.lint]
select = ["E4", "E7", "E9", "F"]
```

`E4`/`E7`/`E9`/`F` are exactly what ruff selected by default through 0.15.x — verified as the same 59 rules under both 0.15.22 and 0.16.1. No lint findings change today; the difference is that the next bump can no longer move the goalposts.

Adopting a broader rule set (any subset of the 413) is worth doing, but as a deliberate PR that also fixes the resulting findings — not as a side effect of a version bump.

## Verification

Using `pycubrid/ tests/`, the exact paths the `lint` job checks:

```
ruff@0.15.22 check          All checks passed!
ruff@0.15.22 format --check 56 files already formatted
ruff@0.16.1  check          All checks passed!
ruff@0.16.1  format --check 56 files already formatted
scripts/lint_changelog.py   OK: 19 version(s), order valid
```

## Org-wide

Same root cause in the sibling repos — cubrid-mcp-server was fixed in [#90](https://github.com/cubrid-lab/cubrid-mcp-server/pull/90); sqlalchemy-cubrid ([#267](https://github.com/cubrid-lab/sqlalchemy-cubrid/pull/267), 151 errors) and cubrid-cookbook-python (260 errors, `main` already red, no ruff pin at all) still need it. PRs to follow.

Closes #247
